### PR TITLE
Renaming @wait-for-fix to @wait_for_fix

### DIFF
--- a/features/attribute/attribute-listing.feature
+++ b/features/attribute/attribute-listing.feature
@@ -1,4 +1,4 @@
-@attribute_listing @wait-for-fix
+@attribute_listing @wait_for_fix
 Feature: Listing attributi
   Tutti gli utenti autenticati possono leggere la lista degli attributi
 


### PR DESCRIPTION
Just renaming a tag for naming convention