### PR TITLE
Refactor of given steps

### DIFF
--- a/features/agreement/agreement-activate.feature
+++ b/features/agreement/agreement-activate.feature
@@ -8,7 +8,7 @@ Feature: Attivazione richiesta di fruizione
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
     Given "<enteFruitore>" dichiara un attributo dichiarato
     Given "<enteFruitore>" crea un attributo verificato
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quegli attributi con approvazione "MANUAL"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quegli attributi con approvazione "MANUAL"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
     Given "<enteErogatore>" verifica l'attributo verificato a "<enteFruitore>"
     When l'utente richiede una operazione di attivazione di quella richiesta di fruizione
@@ -33,7 +33,7 @@ Feature: Attivazione richiesta di fruizione
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
     Given "<enteFruitore>" dichiara un attributo dichiarato
     Given "<enteFruitore>" crea un attributo verificato
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quegli attributi con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quegli attributi con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
     Given "<enteErogatore>" verifica l'attributo verificato a "<enteFruitore>"
     Given "<enteErogatore>" ha già approvato quella richiesta di fruizione
@@ -52,7 +52,7 @@ Feature: Attivazione richiesta di fruizione
     Given due gruppi di due attributi certificati da "<enteCertificatore>", dei quali "<enteFruitore>" ne possiede uno per gruppo
     Given "<enteErogatore>" crea due gruppi di due attributi verificati
     Given due gruppi di due attributi dichiarati, dei quali "<enteFruitore>" ne possiede uno per gruppo
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quegli attributi con approvazione "MANUAL"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quegli attributi con approvazione "MANUAL"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
     Given "<enteErogatore>" verifica un attributo per ogni gruppo di attributi verificati a "<enteFruitore>"
     When l'utente richiede una operazione di attivazione di quella richiesta di fruizione
@@ -65,7 +65,7 @@ Feature: Attivazione richiesta di fruizione
   @agreement_activate4a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato ACTIVE, ARCHIVED, alla richiesta di attivazione da parte di un utente con sufficienti permessi dell’ente erogatore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "GSP" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente richiede una operazione di attivazione di quella richiesta di fruizione
     Then si ottiene status code 400
@@ -79,7 +79,7 @@ Feature: Attivazione richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES, alla richiesta di attivazione da parte di un utente con sufficienti permessi dell’ente erogatore, ottiene un errore
     Given l'utente è un "admin" di "<enteErogatore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"
@@ -93,16 +93,16 @@ Feature: Attivazione richiesta di fruizione
   @agreement_activate4c
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato REJECTED, alla richiesta di attivazione da parte di un utente con sufficienti permessi dell’ente erogatore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
-    Given un "admin" di "GSP" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
-    Given un "admin" di "PA1" ha già rifiutato quella richiesta di fruizione
+    Given "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "GSP" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
+    Given "PA1" ha già rifiutato quella richiesta di fruizione
     When l'utente richiede una operazione di attivazione di quella richiesta di fruizione
     Then si ottiene status code 400
 
   @agreement_activate5
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato PENDING, alla richiesta di attivazione da parte di un utente con sufficienti permessi dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
     Given "PA1" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
     When l'utente richiede una operazione di attivazione di quella richiesta di fruizione
     Then si ottiene status code 403
@@ -111,7 +111,7 @@ Feature: Attivazione richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato SUSPENDED (riattivazione), con uno o più attributi richiesti non posseduti dal fruitore, alla richiesta di attivazione da parte di un utente con sufficienti permessi dell’ente erogatore, va a buon fine ma la richiesta di fruizione resta in stato "SUSPENDED"
     Given l'utente è un "admin" di "<enteErogatore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "SUSPENDED"

--- a/features/agreement/agreement-archive.feature
+++ b/features/agreement/agreement-archive.feature
@@ -5,7 +5,7 @@ Feature: Archiviazione richiesta di fruizione
   @agreement_archive1a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE, alla richiesta di archiviazione da parte di un utente con sufficienti permessi dell’ente fruitore, va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "<ente>" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di archiviazione della richiesta di fruizione
     Then si ottiene status code <risultato>
@@ -31,7 +31,7 @@ Feature: Archiviazione richiesta di fruizione
   @agreement_archive1b
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato SUSPENDED, alla richiesta di archiviazione da parte di un utente con sufficienti permessi dell’ente fruitore, va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "SUSPENDED" per quell'e-service
     When l'utente richiede una operazione di archiviazione della richiesta di fruizione
     Then si ottiene status code 204
@@ -39,7 +39,7 @@ Feature: Archiviazione richiesta di fruizione
   @agreement_archive2
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE o SUSPENDED, alla richiesta di archiviazione da parte di un utente con sufficienti permessi dell’ente erogatore, ottiene un errore
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente richiede una operazione di archiviazione della richiesta di fruizione
     Then si ottiene status code 403
@@ -52,7 +52,7 @@ Feature: Archiviazione richiesta di fruizione
   @agreement_archive3a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato DRAFT o ARCHIVED, alla richiesta di archiviazione da parte di un utente con sufficienti permessi dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente richiede una operazione di archiviazione della richiesta di fruizione
     Then si ottiene status code 400
@@ -65,7 +65,7 @@ Feature: Archiviazione richiesta di fruizione
   @agreement_archive3b
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato PENDING alla richiesta di archiviazione da parte di un utente con sufficienti permessi dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
     Given "PA1" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
     When l'utente richiede una operazione di archiviazione della richiesta di fruizione
     Then si ottiene status code 400
@@ -73,9 +73,9 @@ Feature: Archiviazione richiesta di fruizione
   @agreement_archive3c
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato REJECTED alla richiesta di archiviazione da parte di un utente con sufficienti permessi dell’ente fruitore, ottiene un errore (NB: verificare status code)
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
     Given "PA1" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
-    Given un "admin" di "PA2" ha già rifiutato quella richiesta di fruizione
+    Given "PA2" ha già rifiutato quella richiesta di fruizione
     When l'utente richiede una operazione di archiviazione della richiesta di fruizione
     Then si ottiene status code 400
 
@@ -83,7 +83,7 @@ Feature: Archiviazione richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES alla richiesta di archiviazione da parte di un utente con sufficienti permessi dell’ente fruitore, ottiene un errore (NB: verificare status code)
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"

--- a/features/agreement/agreement-clone.feature
+++ b/features/agreement/agreement-clone.feature
@@ -5,9 +5,9 @@ Feature: Clonazione di una richiesta di fruizione.
   @agreement_clone1
   Scenario Outline: Un utente con sufficienti permessi, clona una richiesta di fruizione in stato REJECTED. La richiesta va a buon fine.
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
-    Given un "admin" di "<ente>" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
-    Given un "admin" di "PA2" ha già rifiutato quella richiesta di fruizione
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "<ente>" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
+    Given "PA2" ha già rifiutato quella richiesta di fruizione
     When l'utente clona quella richiesta di fruizione
     Then si ottiene status code <risultato>
 
@@ -32,7 +32,7 @@ Feature: Clonazione di una richiesta di fruizione.
   @agreement_clone2a
   Scenario Outline: Un utente con sufficienti permessi, clona una richiesta di fruizione in stato DRAFT, PENDING, ACTIVE, SUSPENDED, ARCHIVED. Ottiene un errore.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente clona quella richiesta di fruizione
     Then si ottiene status code 400
@@ -49,7 +49,7 @@ Feature: Clonazione di una richiesta di fruizione.
   Scenario Outline: Un utente con sufficienti permessi, clona una richiesta di fruizione in stato MISSING_CERTIFIED_ATTRIBUTES. Ottiene un errore.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"

--- a/features/agreement/agreement-consumers-listing.feature
+++ b/features/agreement/agreement-consumers-listing.feature
@@ -5,7 +5,7 @@ Feature: Listing fruitori con richieste di fruizione
   @agreement_consumers_listing1
   Scenario Outline: A fronte di 4 fruitori, restituisce solo i primi 3 risultati
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato e pubblicato 1 e-service
+    Given "<ente>" ha già creato e pubblicato 1 e-service
     Given "PA1" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     Given "PA2" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     Given "GSP" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
@@ -29,7 +29,7 @@ Feature: Listing fruitori con richieste di fruizione
   @agreement_consumers_listing2
   Scenario Outline: A fronte di 4 fruitori con i quali l’erogatore ha almeno una richiesta di fruizione e una richiesta di offset 2, restituisce solo 2 risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 1 e-service
+    Given "PA1" ha già creato e pubblicato 1 e-service
     Given "PA1" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     Given "PA2" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     Given "GSP" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
@@ -40,7 +40,7 @@ Feature: Listing fruitori con richieste di fruizione
   @agreement_consumers_listing3
   Scenario Outline: Restituisce un fruitore il cui nome dell’ente contiene la keyword "Comune di Milano" all'interno del nome, con ricerca case insensitive. In questo scenario il nome di PA1 è "Comune di Milano"
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA2" ha già creato e pubblicato 1 e-service
+    Given "PA2" ha già creato e pubblicato 1 e-service
     Given "PA1" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     Given "GSP" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di listing dei fruitori dei propri e-service filtrando per la keyword "Comune di Milano"
@@ -49,7 +49,7 @@ Feature: Listing fruitori con richieste di fruizione
   @agreement_consumers_listing4
   Scenario Outline: Restituisce un insieme vuoto di fruitori per una ricerca che non porta risultati
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA2" ha già creato e pubblicato 1 e-service
+    Given "PA2" ha già creato e pubblicato 1 e-service
     Given "GSP" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     Given "PA1" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di listing dei fruitori dei propri e-service filtrando per la keyword "unknown"

--- a/features/agreement/agreement-creation.feature
+++ b/features/agreement/agreement-creation.feature
@@ -6,7 +6,7 @@ Feature: Creazione nuova richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi (admin), il cui ente rispetta i requisiti (attributi certificati), senza altre richieste di fruizione per un e-service, crea una nuova richiesta di fruizione in bozza per l’ultima versione disponibile di quell'e-service, la quale è in stato PUBLISHED. La richiesta va a buon fine
     Given l'utente è un "<ruolo>" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     When l'utente crea una richiesta di fruizione in bozza per l'ultima versione di quell'e-service
     Then si ottiene status code <risultato>
 
@@ -32,9 +32,9 @@ Feature: Creazione nuova richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi, il cui ente rispetta i requisiti (attributi certificati), con altre richieste di fruizione in stato REJECTED per un e-service, crea una nuova richiesta di fruizione in bozza per l’ultima versione disponibile di quell'e-service, la quale è in stato PUBLISHED. La richiesta va a buon fine.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "MANUAL"
-    Given un "admin" di "<enteFruitore>" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
-    Given un "admin" di "<enteErogatore>" ha già rifiutato quella richiesta di fruizione
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "MANUAL"
+    Given "<enteFruitore>" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
+    Given "<enteErogatore>" ha già rifiutato quella richiesta di fruizione
     When l'utente crea una richiesta di fruizione in bozza per l'ultima versione di quell'e-service
     Then si ottiene status code 200
 
@@ -46,7 +46,7 @@ Feature: Creazione nuova richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi il cui ente rispetta i requisiti (attributi certificati), con altre richieste di fruizione in stato ARCHIVED per un e-service, crea una nuova richiesta di fruizione in bozza per l’ultima versione disponibile di quell'e-service, la quale è in stato PUBLISHED. La richiesta va a buon fine.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "ARCHIVED" per quell'e-service
     When l'utente crea una richiesta di fruizione in bozza per l'ultima versione di quell'e-service
     Then si ottiene status code 200
@@ -59,7 +59,7 @@ Feature: Creazione nuova richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi, il cui ente NON rispetta i requisiti (attributi certificati), senza altre richieste di fruizione per un e-service, crea una nuova richiesta di fruizione in bozza per l’ultima versione disponibile di quell'e-service, la quale è in stato PUBLISHED; l’e-service è erogato dal suo stesso ente. La richiesta va a buon fine.
     Given l'utente è un "admin" di "PA1"
     Given "PA2" ha creato un attributo certificato e non lo ha assegnato a "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "PA1" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     When l'utente crea una richiesta di fruizione in bozza per l'ultima versione di quell'e-service
     Then si ottiene status code 200
 
@@ -67,7 +67,7 @@ Feature: Creazione nuova richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi il cui ente rispetta i requisiti (attributi certificati), con una richiesta di fruizione in stato DRAFT, PENDING, ACTIVE o SUSPENDED per un e-service, crea una nuova richiesta di fruizione in bozza per l’ultima versione disponibile di quell'e-service, la quale è in stato PUBLISHED. Ottiene un errore.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "<tipoApprovazione>"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "<tipoApprovazione>"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente crea una richiesta di fruizione in bozza per l'ultima versione di quell'e-service
     Then si ottiene status code 409
@@ -83,7 +83,7 @@ Feature: Creazione nuova richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi, il cui ente rispetta i requisiti (attributi certificati), con una richiesta di fruizione in stato MISSING_CERTIFIED_ATTRIBUTES per un e-service, crea una nuova richiesta di fruizione in bozza per l’ultima versione disponibile di quell'e-service, la quale è in stato PUBLISHED. Ottiene un errore.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"
@@ -98,7 +98,7 @@ Feature: Creazione nuova richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi, il cui ente rispetta i requisiti (attributi certificati), senza altre richieste di fruizione per un e-service, crea una nuova richiesta di fruizione in bozza per la penultima versione disponibile di quell'e-service, la quale è in stato DEPRECATED. Ottiene un errore.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "DEPRECATED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "DEPRECATED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     When l'utente crea una richiesta di fruizione in bozza per la penultima versione di quell'e-service
     Then si ottiene status code 400
 
@@ -110,7 +110,7 @@ Feature: Creazione nuova richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi, il cui ente rispetta i requisiti (attributi certificati), senza altre richieste di fruizione per un e-service, crea una nuova richiesta di fruizione in bozza per l’ultima versione disponibile di quell'e-service, la quale è in stato SUSPENDED. Ottiene un errore.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "SUSPENDED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "SUSPENDED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     When l'utente crea una richiesta di fruizione in bozza per l'ultima versione di quell'e-service
     Then si ottiene status code 400
 
@@ -122,7 +122,7 @@ Feature: Creazione nuova richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi, il cui ente NON rispetta i requisiti (attributi certificati), senza altre richieste di fruizione per un e-service; crea una nuova richiesta di fruizione in bozza per l’ultima versione disponibile di quell'e-service, la quale è in stato PUBLISHED. Ottiene un errore.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e non lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     When l'utente crea una richiesta di fruizione in bozza per l'ultima versione di quell'e-service
     Then si ottiene status code 400
 
@@ -134,9 +134,9 @@ Feature: Creazione nuova richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi, il cui ente rispetta i requisiti (attributi certificati), ha già una richiesta di fruizione per quell’e-service in stato ACTIVE. L’erogatore ha già creato una nuova versione dello stesso e-service, in stato PUBLISHED. L’utente del fruitore, crea una nuova bozza di richiesta di fruizione per questa nuova versione. Ottiene un errore.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
-    Given un "admin" di "<enteErogatore>" ha già pubblicato una nuova versione per quell'e-service
+    Given "<enteErogatore>" ha già pubblicato una nuova versione per quell'e-service
     When l'utente crea una richiesta di fruizione in bozza per l'ultima versione di quell'e-service
     Then si ottiene status code 409
 

--- a/features/agreement/agreement-delete.feature
+++ b/features/agreement/agreement-delete.feature
@@ -5,7 +5,7 @@ Feature: Cancellazione richiesta di fruizione
   @agreement_delete1a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato DRAFT, alla richiesta di cancellazione da parte di un utente con sufficienti permessi, va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "<ente>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     When l'utente richiede una operazione di cancellazione della richiesta di fruizione
     Then si ottiene status code <risultato>
@@ -32,7 +32,7 @@ Feature: Cancellazione richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES, alla richiesta di cancellazione da parte di un utente con sufficienti permessi, va a buon fine
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"
@@ -46,7 +46,7 @@ Feature: Cancellazione richiesta di fruizione
   @agreement_delete2a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato PENDING, ACTIVE, SUSPENDED o ARCHIVED, alla richiesta di cancellazione da parte di un utente con sufficienti permessi, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente richiede una operazione di cancellazione della richiesta di fruizione
     Then si ottiene status code 400
@@ -61,8 +61,8 @@ Feature: Cancellazione richiesta di fruizione
   @agreement_delete2b
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato REJECTED, alla richiesta di cancellazione da parte di un utente con sufficienti permessi, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
     Given "PA1" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
-    Given un "admin" di "PA2" ha già rifiutato quella richiesta di fruizione
+    Given "PA2" ha già rifiutato quella richiesta di fruizione
     When l'utente richiede una operazione di cancellazione della richiesta di fruizione
     Then si ottiene status code 400

--- a/features/agreement/agreement-document-delete.feature
+++ b/features/agreement/agreement-document-delete.feature
@@ -5,8 +5,8 @@ Feature: Cancellazione di un documento allegato alla richiesta di fruizione
   @agreement_document_delete1
   Scenario Outline: Un utente con sufficienti permessi, per una richiesta di fruizione precedentemente creata, la quale è in stato DRAFT, cancella un documento associato alla richiesta di fruizione. La richiesta va a buon fine.
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
-    Given un "admin" di "<ente>" ha già creato una richiesta di fruizione in stato "DRAFT" con un documento allegato
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "<ente>" ha già creato una richiesta di fruizione in stato "DRAFT" con un documento allegato
     When l'utente cancella il documento allegato a quella richiesta di fruizione
     Then si ottiene status code <risultato>
 
@@ -31,8 +31,8 @@ Feature: Cancellazione di un documento allegato alla richiesta di fruizione
   @agreement_document_delete2a @wait_for_fix @IMN-310
   Scenario Outline: Un utente con sufficienti permessi, per una richiesta di fruizione precedentemente creata, la quale è in stato PENDING, ACTIVE, SUSPENDED, ARCHIVED, cancella un documento associato alla richiesta di fruizione. Ottiene un errore.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
-    Given un "admin" di "PA1" ha già creato una richiesta di fruizione in stato "<statoAgreement>" con un documento allegato
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA1" ha già creato una richiesta di fruizione in stato "<statoAgreement>" con un documento allegato
     When l'utente cancella il documento allegato a quella richiesta di fruizione
     Then si ottiene status code 403
 
@@ -47,8 +47,8 @@ Feature: Cancellazione di un documento allegato alla richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi, per una richiesta di fruizione precedentemente creata, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES, cancella un documento associato alla richiesta di fruizione. Ottiene un errore.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
-    Given un "admin" di "<enteFruitore>" ha già creato una richiesta di fruizione in stato "DRAFT" con un documento allegato
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteFruitore>" ha già creato una richiesta di fruizione in stato "DRAFT" con un documento allegato
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"
     When l'utente cancella il documento allegato a quella richiesta di fruizione

--- a/features/agreement/agreement-document-read.feature
+++ b/features/agreement/agreement-document-read.feature
@@ -5,8 +5,8 @@ Feature: Lettura di un documento allegato alla richiesta di fruizione
   @agreement_document_read1
   Scenario Outline: Un utente con sufficienti permessi, per una richiesta di fruizione precedentemente creata, la quale è in stato DRAFT, relativa a un e-service pubblicato dallo stesso ente, alla richiesta di lettura di un documento allegato, la richiesta va a buon fine.
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato e pubblicato 1 e-service
-    Given un "admin" di "<ente>" ha già creato una richiesta di fruizione in stato "DRAFT" con un documento allegato
+    Given "<ente>" ha già creato e pubblicato 1 e-service
+    Given "<ente>" ha già creato una richiesta di fruizione in stato "DRAFT" con un documento allegato
     When l'utente richiede una operazione di lettura del documento allegato a quella richiesta di fruizione
     Then si ottiene status code <risultato>
 
@@ -26,8 +26,8 @@ Feature: Lettura di un documento allegato alla richiesta di fruizione
   @agreement_document_read2a
   Scenario Outline: Un utente con sufficienti permessi, per una richiesta di fruizione precedentemente creata, la quale è in stato PENDING, ACTIVE, SUSPENDED, ARCHIVED, alla richiesta di lettura di un documento allegato, la richiesta va a buon fine.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
-    Given un "admin" di "PA1" ha già creato una richiesta di fruizione in stato "<statoAgreement>" con un documento allegato
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA1" ha già creato una richiesta di fruizione in stato "<statoAgreement>" con un documento allegato
     When l'utente richiede una operazione di lettura del documento allegato a quella richiesta di fruizione
     Then si ottiene status code 200
 
@@ -42,8 +42,8 @@ Feature: Lettura di un documento allegato alla richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi, per una richiesta di fruizione precedentemente creata, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES, alla richiesta di lettura di un documento allegato, la richiesta va a buon fine.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
-    Given un "admin" di "<enteFruitore>" ha già creato una richiesta di fruizione in stato "DRAFT" con un documento allegato
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteFruitore>" ha già creato una richiesta di fruizione in stato "DRAFT" con un documento allegato
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"
     When l'utente richiede una operazione di lettura del documento allegato a quella richiesta di fruizione

--- a/features/agreement/agreement-document-upload.feature
+++ b/features/agreement/agreement-document-upload.feature
@@ -5,7 +5,7 @@ Feature: Caricamento di un documento allegato alla richiesta di fruizione
   @agreement_document_upload1
   Scenario Outline: Un utente con sufficienti permessi, per una richiesta di fruizione precedentemente creata, la quale è in stato DRAFT, carica un documento associando un nome al documento (prettyName). La richiesta va a buon fine.
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
     Given "<ente>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     When l'utente carica un documento allegato a quella richiesta di fruizione
     Then si ottiene status code <risultato>
@@ -31,7 +31,7 @@ Feature: Caricamento di un documento allegato alla richiesta di fruizione
   @agreement_document_upload2a @wait_for_fix @IMN-311
   Scenario Outline: Un utente con sufficienti permessi, per una richiesta di fruizione precedentemente creata, la quale è in stato PENDING, ACTIVE, SUSPENDED, ARCHIVED, carica un documento associando un nome al documento (prettyName). Ottiene un errore.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente carica un documento allegato a quella richiesta di fruizione
     Then si ottiene status code 403
@@ -47,7 +47,7 @@ Feature: Caricamento di un documento allegato alla richiesta di fruizione
   Scenario Outline: Un utente con sufficienti permessi, per una richiesta di fruizione precedentemente creata, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES, carica un documento associando un nome al documento (prettyName). Ottiene un errore.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"

--- a/features/agreement/agreement-download.feature
+++ b/features/agreement/agreement-download.feature
@@ -5,7 +5,7 @@ Feature: Download attestazione richiesta di fruizione sigillata
   @agreement_download1a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato ACTIVE, alla richiesta di download dell'attestazione della richiesta di fruizione da parte di un utente con sufficienti permessi, va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "<ente>" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     Given l'attestazione di quella richiesta di fruizione è già stata generata
     When l'utente richiede una operazione di download dell'attestazione della richiesta di fruizione
@@ -37,7 +37,7 @@ Feature: Download attestazione richiesta di fruizione sigillata
   @agreement_download2a @wait_for_fix @IMN-305
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato DRAFT, PENDING, alla richiesta di download dell'attestazione  della richiesta di fruizione sigillata da parte di un utente con sufficienti permessi, ottiene un errore.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente richiede una operazione di download dell'attestazione della richiesta di fruizione
     Then si ottiene status code 400
@@ -50,9 +50,9 @@ Feature: Download attestazione richiesta di fruizione sigillata
   @agreement_download2b @wait_for_fix @IMN-305
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato REJECTED, alla richiesta di download dell'attestazione  della richiesta di fruizione sigillata da parte di un utente con sufficienti permessi, ottiene un errore.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
     Given "PA1" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
-    Given un "admin" di "PA2" ha già rifiutato quella richiesta di fruizione
+    Given "PA2" ha già rifiutato quella richiesta di fruizione
     When l'utente richiede una operazione di download dell'attestazione della richiesta di fruizione
     Then si ottiene status code 400
 
@@ -60,7 +60,7 @@ Feature: Download attestazione richiesta di fruizione sigillata
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES, alla richiesta di download dell'attestazione  della richiesta di fruizione sigillata da parte di un utente con sufficienti permessi, ottiene un errore.
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"

--- a/features/agreement/agreement-e-service-consumer-listing.feature
+++ b/features/agreement/agreement-e-service-consumer-listing.feature
@@ -5,7 +5,7 @@ Feature: Listing e-service con richieste di fruizione attive lato fruitore
   @agreement_e_service_consumer_listing1
   Scenario Outline: Restituisce gli e-service per i quali il fruitore ha almeno una richiesta di fruizione in qualsiasi stato
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato e pubblicato 2 e-services
+    Given "PA2" ha già creato e pubblicato 2 e-services
     Given "<ente>" ha una richiesta di fruizione in stato "ACTIVE" per ognuno di quegli e-services
     When l'utente richiede una operazione di listing degli e-services per cui ha una richiesta di fruizione
     Then si ottiene status code 200 e la lista di 2 e-services
@@ -31,7 +31,7 @@ Feature: Listing e-service con richieste di fruizione attive lato fruitore
   @agreement_e_service_consumer_listing2
   Scenario Outline: A fronte di 5 e-service, restituisce solo i primi 3 risultati
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "PA2" ha una richiesta di fruizione in stato "ACTIVE" per ognuno di quegli e-services
     When l'utente richiede una operazione di listing degli e-services per cui ha una richiesta di fruizione limitata a 3
     Then si ottiene status code 200 e la lista di 3 e-service
@@ -39,7 +39,7 @@ Feature: Listing e-service con richieste di fruizione attive lato fruitore
   @agreement_e_service_consumer_listing3
   Scenario Outline: A fronte di 5 e-service in db e una richiesta di offset 2, restituisce solo 3 risultati
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "PA2" ha una richiesta di fruizione in stato "ACTIVE" per ognuno di quegli e-services
     When l'utente richiede una operazione di listing degli e-services per cui ha una richiesta di fruizione con offset 2
     Then si ottiene status code 200 e la lista di 3 e-service
@@ -47,7 +47,7 @@ Feature: Listing e-service con richieste di fruizione attive lato fruitore
   @agreement_e_service_consumer_listing4
   Scenario Outline: Restituisce gli e-service il cui nome contiene la keyword "test" all'interno del nome, con ricerca case insensitive
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA1" ha già creato e pubblicato un e-service contenente la keyword "test"
+    Given "PA1" ha già creato e pubblicato un e-service contenente la keyword "test"
     Given "PA2" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di listing degli e-services per cui ha una richiesta di fruizione con keyword "test"
     Then si ottiene status code 200 e la lista di 1 e-service
@@ -55,7 +55,7 @@ Feature: Listing e-service con richieste di fruizione attive lato fruitore
   @agreement_e_service_consumer_listing5
   Scenario Outline: Restituisce un insieme vuoto di e-service per una ricerca che non porta risultati (es. stringa “disosfdio sjfjods” all’interno del nome. Scopo del test è verificare che, se non ci sono risultati, il server risponda con 200 e array vuoto e non con un errore)
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA1" ha già creato e pubblicato un e-service contenente la keyword "test"
+    Given "PA1" ha già creato e pubblicato un e-service contenente la keyword "test"
     Given "PA2" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di listing degli e-services per cui ha una richiesta di fruizione con keyword "unknown"
     Then si ottiene status code 200 e la lista di 0 e-service

--- a/features/agreement/agreement-e-service-producer-listing.feature
+++ b/features/agreement/agreement-e-service-producer-listing.feature
@@ -5,9 +5,9 @@ Feature: Listing e-service con richieste di fruizione attive lato erogatore
   @agreement_e_service_producer_listing1 @wait_for_fix @IMN-333
   Scenario Outline: Restituisce gli e-service per i quali l’erogatore ha almeno una richiesta di fruizione in stato NON DRAFT da parte dei fruitori
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "<ente>" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "GSP" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
-    Given un "admin" di "<ente>" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "<ente>" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     When l'utente richiede una operazione di listing degli e-services che hanno una richiesta di fruizione attiva
     Then si ottiene status code 200 e la lista di 1 e-service
@@ -28,7 +28,7 @@ Feature: Listing e-service con richieste di fruizione attive lato erogatore
   @agreement_e_service_producer_listing2
   Scenario Outline: A fronte di 5 e-service, restituisce solo i primi 3 risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "GSP" ha un agreement attivo per ciascun e-service di "PA1"
     When l'utente richiede una operazione di listing degli e-services che hanno una richiesta di fruizione attiva limitata ai primi 3 e-services
     Then si ottiene status code 200 e la lista di 3 e-service
@@ -36,7 +36,7 @@ Feature: Listing e-service con richieste di fruizione attive lato erogatore
   @agreement_e_service_producer_listing3
   Scenario Outline: A fronte di 5 e-service in db e una richiesta di offset 2, restituisce solo 3 risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "GSP" ha un agreement attivo per ciascun e-service di "PA1"
     When l'utente richiede una operazione di listing degli e-services che hanno una richiesta di fruizione attiva con offset 2
     Then si ottiene status code 200 e la lista di 3 e-service
@@ -44,9 +44,9 @@ Feature: Listing e-service con richieste di fruizione attive lato erogatore
   @agreement_e_service_producer_listing4
   Scenario Outline: Restituisce gli e-service il cui nome contiene la keyword "test" all'interno del nome, con ricerca case insensitive
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 2 e-services
+    Given "PA1" ha già creato e pubblicato 2 e-services
     Given "GSP" ha un agreement attivo per ciascun e-service di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato un e-service contenente la keyword "test"
+    Given "PA1" ha già creato e pubblicato un e-service contenente la keyword "test"
     Given "GSP" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di listing degli e-services che hanno una richiesta di fruizione attiva filtrando per la keyword "Test"
     Then si ottiene status code 200 e la lista di 1 e-service
@@ -54,7 +54,7 @@ Feature: Listing e-service con richieste di fruizione attive lato erogatore
   @agreement_e_service_producer_listing5
   Scenario Outline: Restituisce un insieme vuoto di e-service per una ricerca che non porta risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 2 e-services
+    Given "PA1" ha già creato e pubblicato 2 e-services
     Given "GSP" ha un agreement attivo per ciascun e-service di "PA1"
     When l'utente richiede una operazione di listing degli e-services che hanno una richiesta di fruizione attiva filtrando per la keyword "unknown"
     Then si ottiene status code 200 e la lista di 0 e-service

--- a/features/agreement/agreement-listing.feature
+++ b/features/agreement/agreement-listing.feature
@@ -6,7 +6,7 @@ Feature: Listing richieste di fruizione
   @agreement_listing1
   Scenario Outline: A fronte di 5 richieste di fruizione in db, restituisce solo i primi 3 risultati
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "<ente>" ha un agreement attivo per ciascun e-service di "PA1"
     When l'utente richiede una operazione di listing limitata alle prime 3 richieste di fruizione
     Then si ottiene status code 200 e la lista di 3 richieste di fruizione
@@ -32,7 +32,7 @@ Feature: Listing richieste di fruizione
   @agreement_listing2
   Scenario Outline: A fronte di 5 richieste di fruizione in db e una richiesta di offset 3, restituisce solo 2 risultati
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "GSP" ha un agreement attivo per ciascun e-service di "PA1"
     When l'utente richiede una operazione di listing con offset 3
     Then si ottiene status code 200 e la lista di 2 richieste di fruizione
@@ -40,7 +40,7 @@ Feature: Listing richieste di fruizione
   @agreement_listing3
   Scenario Outline: Restituisce le richieste di fruizione che un erogatore si trova create dai fruitori dei propri e-service
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "PA2" ha un agreement attivo per ciascun e-service di "PA1"
     Given "GSP" ha un agreement attivo per ciascun e-service di "PA1"
     When l'utente richiede una operazione di listing delle richieste di fruizione ai propri e-service
@@ -49,7 +49,7 @@ Feature: Listing richieste di fruizione
   @agreement_listing4
   Scenario Outline: Restituisce le richieste di fruizione che un fruitore ha creato
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "PA2" ha un agreement attivo per ciascun e-service di "PA1"
     Given "GSP" ha un agreement attivo per ciascun e-service di "PA1"
     When l'utente richiede una operazione di listing delle richieste di fruizione che ha creato
@@ -58,7 +58,7 @@ Feature: Listing richieste di fruizione
   @agreement_listing5
   Scenario Outline: Restituisce le richieste di fruizione associate ad alcuni specifici e-service
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "GSP" ha un agreement attivo per ciascun e-service di "PA1"
     Given "PA2" ha un agreement attivo per ciascun e-service di "PA1"
     When l'utente richiede una operazione di listing delle richieste di fruizione per 3 specifici e-service
@@ -67,7 +67,7 @@ Feature: Listing richieste di fruizione
   @agreement_listing6
   Scenario Outline: Restituisce le richieste di fruizione di uno specifico fruitore che sono in uno o più specifici stati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "GSP" ha un agreement in stato "ACTIVE" per l'e-service numero 1 di "PA1"
     Given "GSP" ha un agreement in stato "DRAFT" per l'e-service numero 2 di "PA1"
     Given "GSP" ha un agreement in stato "SUSPENDED" per l'e-service numero 3 di "PA1"
@@ -77,15 +77,15 @@ Feature: Listing richieste di fruizione
   @agreement_listing7
   Scenario Outline: Restituisce le richieste di fruizione di uno specifico fruitore che possono essere aggiornate ad una nuova versione di e-service
     Given l'utente è un "admin" di "GSP"
-    Given un "admin" di "PA1" ha già creato e pubblicato 5 e-services
+    Given "PA1" ha già creato e pubblicato 5 e-services
     Given "GSP" ha un agreement attivo per ciascun e-service di "PA1"
-    Given un "admin" di "PA1" ha già pubblicato una nuova versione per 2 di questi e-service
+    Given "PA1" ha già pubblicato una nuova versione per 2 di questi e-service
     When l'utente richiede una operazione di listing delle richieste di fruizione aggiornabili
     Then si ottiene status code 200 e la lista di 2 richieste di fruizione
 
   @agreement_listing8
   Scenario Outline: Restituisce un insieme vuoto di richieste di fruizione per una ricerca che non porta risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 2 e-services
+    Given "PA1" ha già creato e pubblicato 2 e-services
     When l'utente richiede una operazione di listing delle richieste di fruizione
     Then si ottiene status code 200 e la lista di 0 richieste di fruizione

--- a/features/agreement/agreement-producers-listing.feature
+++ b/features/agreement/agreement-producers-listing.feature
@@ -5,11 +5,11 @@ Feature: Listing erogatori con richieste di fruizione
   @agreement_producers_listing1
   Scenario Outline: A fronte di 3 erogatori, restituisce solo i primi 2 risultati
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA1" ha già creato e pubblicato 1 e-service
+    Given "PA1" ha già creato e pubblicato 1 e-service
     Given "<ente>" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
-    Given un "admin" di "PA2" ha già creato e pubblicato 1 e-service
+    Given "PA2" ha già creato e pubblicato 1 e-service
     Given "<ente>" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
-    Given un "admin" di "GSP" ha già creato e pubblicato 1 e-service
+    Given "GSP" ha già creato e pubblicato 1 e-service
     Given "<ente>" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di listing degli erogatori degli e-service per cui ha una richiesta di fruizione limitata ai primi 2
     Then si ottiene status code 200 e la lista di 2 erogatori
@@ -35,11 +35,11 @@ Feature: Listing erogatori con richieste di fruizione
   @agreement_producers_listing2
   Scenario Outline: A fronte di 3 erogatori con i quali il fruitore ha almeno una richiesta di fruizione e una richiesta di offset 2, restituisce solo 1 risultato
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 1 e-service
+    Given "PA1" ha già creato e pubblicato 1 e-service
     Given "PA1" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
-    Given un "admin" di "PA2" ha già creato e pubblicato 1 e-service
+    Given "PA2" ha già creato e pubblicato 1 e-service
     Given "PA1" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
-    Given un "admin" di "GSP" ha già creato e pubblicato 1 e-service
+    Given "GSP" ha già creato e pubblicato 1 e-service
     Given "PA1" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di listing degli erogatori degli e-service per cui ha una richiesta di fruizione con offset 2
     Then si ottiene status code 200 con la corretta verifica dell'offset
@@ -47,9 +47,9 @@ Feature: Listing erogatori con richieste di fruizione
   @agreement_producers_listing3
   Scenario Outline: Restituisce gli erogatori il cui nome dell’ente contiene la keyword "Comune di Milano" all'interno del nome, con ricerca case insensitive. In questo scenario il nome di PA1 è "Comune di Milano"
     Given l'utente è un "admin" di "GSP"
-    Given un "admin" di "PA1" ha già creato e pubblicato 1 e-service
+    Given "PA1" ha già creato e pubblicato 1 e-service
     Given "GSP" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
-    Given un "admin" di "PA2" ha già creato e pubblicato 1 e-service
+    Given "PA2" ha già creato e pubblicato 1 e-service
     Given "GSP" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di listing degli erogatori degli e-service per cui ha una richiesta di fruizione filtrando per la keyword "Comune di Milano"
     Then si ottiene status code 200 e la lista di 1 erogatore
@@ -57,9 +57,9 @@ Feature: Listing erogatori con richieste di fruizione
   @agreement_producers_listing4
   Scenario Outline: Restituisce un insieme vuoto di erogatori per una ricerca che non porta risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato e pubblicato 1 e-service
+    Given "PA1" ha già creato e pubblicato 1 e-service
     Given "PA1" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
-    Given un "admin" di "PA2" ha già creato e pubblicato 1 e-service
+    Given "PA2" ha già creato e pubblicato 1 e-service
     Given "PA1" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di listing degli erogatori degli e-service per cui ha una richiesta di fruizione filtrando per la keyword "unknown"
     Then si ottiene status code 200 e la lista di 0 erogatori

--- a/features/agreement/agreement-read.feature
+++ b/features/agreement/agreement-read.feature
@@ -5,9 +5,9 @@ Feature: Lettura richiesta di fruizione
   @agreement_read1
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato REJECTED, alla richiesta di lettura, va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
-    Given un "admin" di "GSP" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
-    Given un "admin" di "PA1" ha già rifiutato quella richiesta di fruizione
+    Given "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "GSP" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
+    Given "PA1" ha già rifiutato quella richiesta di fruizione
     When l'utente richiede una operazione di lettura di quell'agreement
     Then si ottiene status code 200
 
@@ -31,7 +31,7 @@ Feature: Lettura richiesta di fruizione
   @agreement_read2
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato DRAFT, PENDING, ACTIVE, SUSPENDED o ARCHIVED, alla richiesta di lettura, va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
     Given "GSP" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente richiede una operazione di lettura di quell'agreement
     Then si ottiene status code 200
@@ -48,7 +48,7 @@ Feature: Lettura richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES, alla richiesta di lettura, va a buon fine
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"
@@ -62,7 +62,7 @@ Feature: Lettura richiesta di fruizione
   @agreement_read4
   Scenario Outline: Per una richiesta di fruizione precedentemente creata dall’ente, la quale è in stato ACTIVE, alla richiesta di lettura da parte di un ente nè fruitore nè erogatore, va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "GSP" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "GSP" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA2" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di lettura di quell'agreement
     Then si ottiene status code 200

--- a/features/agreement/agreement-rejection.feature
+++ b/features/agreement/agreement-rejection.feature
@@ -7,7 +7,7 @@ Feature: Rifiuto di una richiesta di fruizione
     Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato PENDING, alla richiesta di rifiuto con messaggio da parte di un utente con sufficienti permessi (admin) dell’ente erogatore, va a buon fine
 
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "<ente>" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
     Given "PA2" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
     When l'utente richiede una operazione di rifiuto di quella richiesta di fruizione con messaggio
     Then si ottiene status code <risultato>
@@ -28,7 +28,7 @@ Feature: Rifiuto di una richiesta di fruizione
   @agreement_rejection2
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato PENDING, alla richiesta di rifiuto SENZA messaggio da parte di un utente con sufficienti permessi dell’ente erogatore, ottiene un errore (NB: verificare status code)
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
     Given "PA1" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
     When l'utente richiede una operazione di rifiuto di quella richiesta di fruizione senza messaggio
     Then si ottiene status code 400
@@ -36,7 +36,7 @@ Feature: Rifiuto di una richiesta di fruizione
   @agreement_rejection3a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato ACTIVE, SUSPENDED o ARCHIVED,alla richiesta di rifiuto con messaggio da parte di un utente con sufficienti permessi dell’ente erogatore, ottiene un errore
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente richiede una operazione di rifiuto di quella richiesta di fruizione con messaggio
     Then si ottiene status code 400
@@ -50,8 +50,8 @@ Feature: Rifiuto di una richiesta di fruizione
   @agreement_rejection3b
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato REJECTED,alla richiesta di rifiuto con messaggio da parte di un utente con sufficienti permessi dell’ente erogatore, ottiene un errore
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
-    Given un "admin" di "PA1" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
-    Given un "admin" di "PA2" ha già rifiutato quella richiesta di fruizione
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA1" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
+    Given "PA2" ha già rifiutato quella richiesta di fruizione
     When l'utente richiede una operazione di rifiuto di quella richiesta di fruizione con messaggio
     Then si ottiene status code 400

--- a/features/agreement/agreement-submit.feature
+++ b/features/agreement/agreement-submit.feature
@@ -5,7 +5,7 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   @agreement_submit1
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato DRAFT, associata ad un e-service nella sua ultima versione pubblicata, la quale è in stato PUBLISHED, all'inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi dell’ente fruitore, va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "<ente>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     When l'utente inoltra quella richiesta di fruizione
     Then si ottiene status code <risultato>
@@ -31,7 +31,7 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   @agreement_submit2 @wait_for_fix @IMN-309
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato DRAFT, associata ad un e-service nella sua ultima versione pubblicata, la quale è in stato SUSPENDED, all'inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi dell’ente fruitore, dà errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "PA2" ha sospeso quell'e-service
     When l'utente inoltra quella richiesta di fruizione
@@ -41,7 +41,7 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato DRAFT, associata ad un e-service nella sua ultima versione pubblicata, con NON tutti gli attributi richiesti certificati, all’inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi dell’ente fruitore, che è anche l’erogatore dell’e-service, va a buon fine
     Given l'utente è un "admin" di "PA2"
     Given "PA2" ha creato un attributo certificato e non lo ha assegnato a "PA2"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "PA2" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     When l'utente inoltra quella richiesta di fruizione
     Then si ottiene status code 200
@@ -49,7 +49,7 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   @agreement_submit4
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato DRAFT, associata ad un e-service nella sua ultima versione pubblicata, la quale versione ha attivazione manuale delle richieste di fruizione e che non richiede attributi, all’inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi (admin) dell’ente fruitore, va a buon fine, e la richiesta di fruizione passa in stato PENDING
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
     Given "PA1" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     When l'utente inoltra quella richiesta di fruizione
     Then la richiesta di fruizione assume lo stato "PENDING"
@@ -57,7 +57,7 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   @agreement_submit5
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato DRAFT, associata ad un e-service nella sua ultima versione pubblicata, la quale versione ha attivazione automatica delle richieste di fruizione (agreementApprovalPolicy = AUTOMATIC), e che non richiede attributi, all’inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi (admin) dell’ente fruitore, va a buon fine, e la richiesta di fruizione passa in stato ACTIVE
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     When l'utente inoltra quella richiesta di fruizione
     Then la richiesta di fruizione assume lo stato "ACTIVE"
@@ -66,7 +66,7 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato DRAFT, associata ad un e-service nella sua ultima versione pubblicata, la quale versione ha attivazione automatica delle richieste di fruizione con almeno un attributo verificato che il fruitore NON possiede, all’inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi dell’ente fruitore, va a buon fine, e la richiesta di fruizione passa in stato PENDING
     Given l'utente è un "admin" di "PA1"
     Given "GSP" crea un attributo verificato
-    Given un "admin" di "GSP" ha già creato un e-service in stato "PUBLISHED" che richiede quegli attributi con approvazione "AUTOMATIC"
+    Given "GSP" ha già creato un e-service in stato "PUBLISHED" che richiede quegli attributi con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     When l'utente inoltra quella richiesta di fruizione
     Then la richiesta di fruizione assume lo stato "PENDING"
@@ -74,7 +74,7 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   @agreement_submit7a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato PENDING, ACTIVE, SUSPENDED, ARCHIVED, associata ad un e-service nella sua ultima versione pubblicata, all’inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi (admin) dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente inoltra quella richiesta di fruizione
     Then si ottiene status code 400
@@ -89,9 +89,9 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   @agreement_submit7b
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato REJECTED associata ad un e-service nella sua ultima versione pubblicata, all’inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi (admin) dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
     Given "PA1" ha una richiesta di fruizione in stato "PENDING" per quell'e-service
-    Given un "admin" di "PA2" ha già rifiutato quella richiesta di fruizione
+    Given "PA2" ha già rifiutato quella richiesta di fruizione
     When l'utente inoltra quella richiesta di fruizione
     Then si ottiene status code 400
 
@@ -99,7 +99,7 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato DRAFT, associata ad un e-service nella sua ultima versione pubblicata, MA NON tutti gli attributi richiesti dichiarati dal fruitore, all’inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi (admin) dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
     Given "PA1" non possiede uno specifico attributo dichiarato
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" che richiede quegli attributi con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" che richiede quegli attributi con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     When l'utente inoltra quella richiesta di fruizione
     Then si ottiene status code 400
@@ -108,7 +108,7 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES, associata ad un e-service nella sua ultima versione pubblicata, con NON tutti gli attributi richiesti certificati, all’inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi (admin) dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"
@@ -122,8 +122,8 @@ Tutti gli utenti autorizzati possono inoltrare una richiesta di fruizione
   @agreement_submit10
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato DRAFT, associata ad un e-service NON nella sua ultima versione pubblicata, all’inoltro della richiesta di fruizione da parte di un utente con sufficienti permessi (admin) dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service
     When l'utente inoltra quella richiesta di fruizione
     Then si ottiene status code 400

--- a/features/agreement/agreement-suspension.feature
+++ b/features/agreement/agreement-suspension.feature
@@ -5,7 +5,7 @@ Feature: Sospensione richiesta di fruizione
   @agreement_suspension1
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE, alla richiesta di sospensione da parte di un utente con sufficienti permessi dell’ente fruitore, che non coincide con l’ente erogatore, va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "<ente>" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di sospensione di quella richiesta di fruizione
     Then si ottiene status code <risultato>
@@ -31,7 +31,7 @@ Feature: Sospensione richiesta di fruizione
   @agreement_suspension2
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE, alla richiesta di sospensione da parte di un utente con sufficienti permessi dell’ente erogatore, che non coincide con l’ente fruitore, va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA2" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di sospensione di quella richiesta di fruizione
     Then si ottiene status code 200
@@ -39,7 +39,7 @@ Feature: Sospensione richiesta di fruizione
   @agreement_suspension3
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE, alla richiesta di sospensione da parte di un utente con sufficienti permessi dell’ente erogatore, che coincide con l’ente fruitore, va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
     When l'utente richiede una operazione di sospensione di quella richiesta di fruizione
     Then si ottiene status code 200
@@ -47,7 +47,7 @@ Feature: Sospensione richiesta di fruizione
   @agreement_suspension4a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato NON ACTIVE (PENDING, DRAFT, SUSPENDED, ARCHIVED), alla richiesta di sospensione da parte di un utente con sufficienti permessi, ottiene un errore. Nel caso in cui lo caso lo stato sia SUSPENDED il risultato sarà 200 per implementazione del pattern di idempotenza.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente richiede una operazione di sospensione di quella richiesta di fruizione
     Then si ottiene status code <risultato>
@@ -62,9 +62,9 @@ Feature: Sospensione richiesta di fruizione
   @agreement_suspension4b
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato REJECTED, alla richiesta di sospensione da parte di un utente con sufficienti permessi, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
-    Given un "admin" di "PA1" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
-    Given un "admin" di "PA2" ha già rifiutato quella richiesta di fruizione
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA1" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
+    Given "PA2" ha già rifiutato quella richiesta di fruizione
     When l'utente richiede una operazione di sospensione di quella richiesta di fruizione
     Then si ottiene status code 400
 
@@ -72,7 +72,7 @@ Feature: Sospensione richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES, alla richiesta di sospensione da parte di un utente con sufficienti permessi, ottiene un errore
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"

--- a/features/agreement/agreement-update.feature
+++ b/features/agreement/agreement-update.feature
@@ -5,7 +5,7 @@ Feature: Aggiornamento di una richiesta di fruizione in bozza
   @agreement_update1
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato DRAFT, alla richiesta di aggiornamento della bozza da parte di un utente con sufficienti permessi dell’ente fruitore con un messaggio per l’erogatore (consumerNotes) aggiornato, va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA1" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "<ente>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     When l'utente richiede una operazione di aggiornamento di quella richiesta di fruizione con messaggio
     Then si ottiene status code <risultato>
@@ -30,9 +30,9 @@ Feature: Aggiornamento di una richiesta di fruizione in bozza
   @agreement_update2a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato REJECTED, alla richiesta di aggiornamento della bozza da parte di un utente con sufficienti permessi dell’ente fruitore con un messaggio per l’erogatore (consumerNotes) aggiornato, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "GSP" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
-    Given un "admin" di "PA1" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
-    Given un "admin" di "GSP" ha già rifiutato quella richiesta di fruizione
+    Given "GSP" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA1" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
+    Given "GSP" ha già rifiutato quella richiesta di fruizione
     When l'utente richiede una operazione di aggiornamento di quella richiesta di fruizione con messaggio
     Then si ottiene status code 400
 
@@ -40,7 +40,7 @@ Feature: Aggiornamento di una richiesta di fruizione in bozza
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES, alla richiesta di aggiornamento della bozza da parte di un utente con sufficienti permessi dell’ente fruitore con un messaggio per l’erogatore (consumerNotes) aggiornato, ottiene un errore
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"
@@ -54,7 +54,7 @@ Feature: Aggiornamento di una richiesta di fruizione in bozza
   @agreement_update2c
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore, la quale è in stato NON DRAFT (PENDING, ACTIVE, SUSPENDED, ARCHIVED), alla richiesta di aggiornamento della bozza da parte di un utente con sufficienti permessi dell’ente fruitore con un messaggio per l’erogatore (consumerNotes) aggiornato, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente richiede una operazione di aggiornamento di quella richiesta di fruizione con messaggio
     Then si ottiene status code 400

--- a/features/agreement/agreement-upgrade.feature
+++ b/features/agreement/agreement-upgrade.feature
@@ -5,9 +5,9 @@ Feature: Upgrade di una richiesta di fruizione
   @agreement_upgrade1a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE, e associata ad una versione di e-service antecedente all’ultima versione pubblicata, alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "<ente>" ha una richiesta di fruizione in stato "ACTIVE" per quell'e-service
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code <risultato>
 
@@ -32,16 +32,16 @@ Feature: Upgrade di una richiesta di fruizione
   @agreement_upgrade1b
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato SUSPENDED, e associata ad una versione di e-service antecedente all’ultima versione pubblicata, alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "SUSPENDED" per quell'e-service
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code 200
 
   @agreement_upgrade2
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE o SUSPENDED, e associata all’ultima versione di e-service pubblicata, alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code 400
@@ -54,10 +54,10 @@ Feature: Upgrade di una richiesta di fruizione
   @agreement_upgrade3a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato REJECTED, e associata ad una versione di e-service antecedente all’ultima versione di e-service pubblicata, alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
-    Given un "admin" di "PA1" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
-    Given un "admin" di "PA2" ha già rifiutato quella richiesta di fruizione
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "MANUAL"
+    Given "PA1" ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione
+    Given "PA2" ha già rifiutato quella richiesta di fruizione
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code 400
 
@@ -65,11 +65,11 @@ Feature: Upgrade di una richiesta di fruizione
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato MISSING_CERTIFIED_ATTRIBUTES e associata ad una versione di e-service antecedente all’ultima versione di e-service pubblicata, alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "<enteFruitore>"
     Given "<enteCertificatore>" ha creato un attributo certificato e lo ha assegnato a "<enteFruitore>"
-    Given un "admin" di "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
+    Given "<enteErogatore>" ha già creato un e-service in stato "PUBLISHED" che richiede quell'attributo certificato con approvazione "AUTOMATIC"
     Given "<enteFruitore>" ha una richiesta di fruizione in stato "DRAFT" per quell'e-service
     Given "<enteCertificatore>" ha già revocato quell'attributo a "<enteFruitore>"
     Given la richiesta di fruizione è passata in stato "MISSING_CERTIFIED_ATTRIBUTES"
-    Given un "admin" di "<enteErogatore>" ha già pubblicato una nuova versione per quell'e-service richiedendo gli stessi attributi certificati
+    Given "<enteErogatore>" ha già pubblicato una nuova versione per quell'e-service richiedendo gli stessi attributi certificati
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code 400
 
@@ -80,9 +80,9 @@ Feature: Upgrade di una richiesta di fruizione
   @agreement_upgrade3c
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato PENDING, DRAFT o ARCHIVED, e associata ad una versione di e-service antecedente all’ultima versione di e-service pubblicata, alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "<tipoApprovazione>"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code 400
 
@@ -95,10 +95,10 @@ Feature: Upgrade di una richiesta di fruizione
   @agreement_upgrade4 @wait_for_fix @IMN-351
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE o SUSPENDED, e associata ad una versione di e-service antecedente all’ultima versione pubblicata, all'interno della nuova versione SONO cambiati gli attributi rispetto alla versione precedente, ed il fruitore non ne possegga uno o più tra quelli CERTIFICATI, alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "GSP" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "GSP" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
     Given "PA2" ha creato un attributo certificato e non lo ha assegnato a "PA1"
-    Given un "admin" di "GSP" ha già pubblicato una nuova versione per quell'e-service richiedendo gli stessi attributi certificati
+    Given "GSP" ha già pubblicato una nuova versione per quell'e-service richiedendo gli stessi attributi certificati
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code 400
 
@@ -110,9 +110,9 @@ Feature: Upgrade di una richiesta di fruizione
   @agreement_upgrade5a
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE o SUSPENDED, e associata ad una versione di e-service antecedente all’ultima versione pubblicata, all'interno della nuova versione SONO cambiati gli attributi rispetto alla versione precedente, ed il fruitore non ne possegga uno o più tra quelli DICHIARATI, alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service che richiede un attributo "DECLARED" che "PA1" non possiede
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service che richiede un attributo "DECLARED" che "PA1" non possiede
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code 200 ed è stata creata una nuova richiesta di fruizione in DRAFT
 
@@ -124,9 +124,9 @@ Feature: Upgrade di una richiesta di fruizione
   @agreement_upgrade5b
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE o SUSPENDED, e associata ad una versione di e-service antecedente all’ultima versione pubblicata, all'interno della nuova versione SONO cambiati gli attributi rispetto alla versione precedente, ed il fruitore non ne possegga uno o più tra quelli VERIFICATI, alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service che richiede un attributo "VERIFIED" che "PA1" non possiede
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service che richiede un attributo "VERIFIED" che "PA1" non possiede
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code 200 ed è stata creata una nuova richiesta di fruizione in DRAFT
 
@@ -138,10 +138,10 @@ Feature: Upgrade di una richiesta di fruizione
   @agreement_upgrade6
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE o SUSPENDED, e associata ad una versione di e-service due indietro rispetto all’ultima versione pubblicata, nella quale nuova versione non sono cambiati gli attributi rispetto alle versioni precedenti, alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, va a buon fine.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code 200 e la nuova richiesta di fruizione è associata alla versione 3 dell'eservice
 
@@ -153,10 +153,10 @@ Feature: Upgrade di una richiesta di fruizione
   @agreement_upgrade7 @wait_for_fix @IMN-351
   Scenario Outline: Per una richiesta di fruizione precedentemente creata da un fruitore e attivata da un erogatore, la quale è in stato ACTIVE o SUSPENDED, e associata ad una versione di e-service due indietro rispetto all’ultima versione pubblicata, all'interno della versione 2 non sono sono cambiati gli attributi rispetto alla versione 1; all'interno della versione 3 sono cambiati gli attributi rispetto alla versione 2 e il fruitore NON possiede almeno uno dei CERTIFICATI; alla richiesta di aggiornamento da parte di un utente con sufficienti permessi dell’ente fruitore, dà errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
+    Given "PA2" ha già creato un e-service in stato "PUBLISHED" con approvazione "AUTOMATIC"
     Given "PA1" ha una richiesta di fruizione in stato "<statoAgreement>" per quell'e-service
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service
-    Given un "admin" di "PA2" ha già pubblicato una nuova versione per quell'e-service che richiede un attributo "CERTIFIED" che "PA1" non possiede
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service
+    Given "PA2" ha già pubblicato una nuova versione per quell'e-service che richiede un attributo "CERTIFIED" che "PA1" non possiede
     When l'utente richiede un'operazione di upgrade di quella richiesta di fruizione
     Then si ottiene status code 400
 

--- a/features/agreement/step_definitions/agreement-activate.ts
+++ b/features/agreement/step_definitions/agreement-activate.ts
@@ -7,7 +7,7 @@ import {
   getAuthorizationHeader,
   getToken,
 } from "../../../utils/commons";
-import { Role, TenantType } from "../../common-steps";
+import { TenantType } from "../../common-steps";
 import {
   EServiceDescriptorState,
   AgreementApprovalPolicy,
@@ -53,9 +53,8 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già creato un e-service in stato {string} che richiede quegli attributi con approvazione {string}",
+  "{string} ha già creato un e-service in stato {string} che richiede quegli attributi con approvazione {string}",
   async function (
-    role: Role,
     tenantType: TenantType,
     descriptorState: EServiceDescriptorState,
     agreementApprovalPolicy: AgreementApprovalPolicy
@@ -70,7 +69,7 @@ Given(
     const requiredDeclaredAttributes = this.requiredDeclaredAttributes ?? [];
     const requiredVerifiedAttributes = this.requiredVerifiedAttributes ?? [];
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     this.eserviceId = await dataPreparationService.createEService(token);
     const response =
       await dataPreparationService.createDescriptorWithGivenState({

--- a/features/agreement/step_definitions/agreement-common-steps.ts
+++ b/features/agreement/step_definitions/agreement-common-steps.ts
@@ -1,6 +1,6 @@
 import { Given } from "@cucumber/cucumber";
 import { z } from "zod";
-import { Role, TenantType } from "../../common-steps";
+import { TenantType } from "../../common-steps";
 import { dataPreparationService } from "../../../services/data-preparation.service";
 import {
   assertContextSchema,
@@ -14,15 +14,14 @@ import {
 } from "../../../api/models";
 
 Given(
-  "un {string} di {string} ha già creato un e-service in stato {string} con approvazione {string}",
+  "{string} ha già creato un e-service in stato {string} con approvazione {string}",
   async function (
-    role: Role,
     tenantType: TenantType,
     descriptorState: EServiceDescriptorState,
     agreementApprovalPolicy: AgreementApprovalPolicy
   ) {
     assertContextSchema(this);
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     this.eserviceId = await dataPreparationService.createEService(token);
     const response =
       await dataPreparationService.createDescriptorWithGivenState({
@@ -36,10 +35,10 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già creato e pubblicato {int} e-service(s)",
-  async function (role: Role, tenantType: TenantType, totalEservices: number) {
+  "{string} ha già creato e pubblicato {int} e-service(s)",
+  async function (tenantType: TenantType, totalEservices: number) {
     assertContextSchema(this);
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
 
     const arr = new Array(totalEservices).fill(0);
     const createEServiceWithPublishedDescriptor = async (i: number) => {
@@ -148,18 +147,14 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già creato una richiesta di fruizione in stato {string} con un documento allegato",
-  async function (
-    role: Role,
-    consumer: TenantType,
-    agreementState: AgreementState
-  ) {
+  "{string} ha già creato una richiesta di fruizione in stato {string} con un documento allegato",
+  async function (consumer: TenantType, agreementState: AgreementState) {
     assertContextSchema(this, {
       eserviceId: z.string(),
       descriptorId: z.string(),
       token: z.string(),
     });
-    const token = getToken(this.tokens, consumer, role);
+    const token = getToken(this.tokens, consumer, "admin");
     const [agreementId, documentId] =
       await dataPreparationService.createAgreementWithGivenStateAndDocument(
         token,

--- a/features/agreement/step_definitions/agreement-creation.ts
+++ b/features/agreement/step_definitions/agreement-creation.ts
@@ -17,15 +17,14 @@ import {
 } from "../../../api/models";
 
 Given(
-  "un {string} di {string} ha già creato un e-service in stato {string} che richiede quell'attributo certificato con approvazione {string}",
+  "{string} ha già creato un e-service in stato {string} che richiede quell'attributo certificato con approvazione {string}",
   async function (
-    role: Role,
     tenantType: TenantType,
     descriptorState: EServiceDescriptorState,
     agreementApprovalPolicy: AgreementApprovalPolicy
   ) {
     assertContextSchema(this, { attributeId: z.string() });
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     this.eserviceId = await dataPreparationService.createEService(token);
     const response =
       await dataPreparationService.createDescriptorWithGivenState({
@@ -46,14 +45,14 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione",
-  async function (role: Role, tenantType: TenantType) {
+  "{string} ha già creato e inviato una richiesta di fruizione per quell'e-service ed è in attesa di approvazione",
+  async function (tenantType: TenantType) {
     assertContextSchema(this, {
       token: z.string(),
       eserviceId: z.string(),
       descriptorId: z.string(),
     });
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     this.agreementId = await dataPreparationService.createAgreement(
       token,
       this.eserviceId,
@@ -68,12 +67,12 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già rifiutato quella richiesta di fruizione",
-  async function (role: Role, tenantType: TenantType) {
+  "{string} ha già rifiutato quella richiesta di fruizione",
+  async function (tenantType: TenantType) {
     assertContextSchema(this, {
       agreementId: z.string(),
     });
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     await dataPreparationService.rejectAgreement(token, this.agreementId);
   }
 );
@@ -123,12 +122,12 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già pubblicato una nuova versione per quell'e-service",
-  async function (role: Role, tenantType: TenantType) {
+  "{string} ha già pubblicato una nuova versione per quell'e-service",
+  async function (tenantType: TenantType) {
     assertContextSchema(this, {
       eserviceId: z.string(),
     });
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     const response =
       await dataPreparationService.createDescriptorWithGivenState({
         token,

--- a/features/agreement/step_definitions/agreement-listing.ts
+++ b/features/agreement/step_definitions/agreement-listing.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../utils/commons";
 import { apiClient } from "../../../api";
 import { dataPreparationService } from "../../../services/data-preparation.service";
-import { TenantType, SessionTokens, Role } from "../../common-steps";
+import { TenantType, SessionTokens } from "../../common-steps";
 import { AgreementState } from "../../../api/models";
 
 Given(
@@ -62,17 +62,13 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già pubblicato una nuova versione per {int} di questi e-service",
-  async function (
-    role: Role,
-    tenantType: TenantType,
-    descriptorsCount: number
-  ) {
+  "{string} ha già pubblicato una nuova versione per {int} di questi e-service",
+  async function (tenantType: TenantType, descriptorsCount: number) {
     assertContextSchema(this, {
       publishedEservicesIds: z.array(z.tuple([z.string(), z.string()])),
     });
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     const eserviceIds = this.publishedEservicesIds
       .slice(0, descriptorsCount)
       .map(([eserviceId, _]) => eserviceId);

--- a/features/agreement/step_definitions/agreement-upgrade.ts
+++ b/features/agreement/step_definitions/agreement-upgrade.ts
@@ -8,7 +8,7 @@ import {
   makePolling,
 } from "../../../utils/commons";
 import { apiClient } from "../../../api";
-import { Role, TenantType } from "../../common-steps";
+import { TenantType } from "../../common-steps";
 import { dataPreparationService } from "../../../services/data-preparation.service";
 import { AttributeKind, DescriptorAttributeSeed } from "../../../api/models";
 
@@ -27,14 +27,14 @@ When(
 );
 
 Given(
-  "un {string} di {string} ha già pubblicato una nuova versione per quell'e-service richiedendo gli stessi attributi certificati",
-  async function (role: Role, tenantType: TenantType) {
+  "{string} ha già pubblicato una nuova versione per quell'e-service richiedendo gli stessi attributi certificati",
+  async function (tenantType: TenantType) {
     assertContextSchema(this, {
       token: z.string(),
       eserviceId: z.string(),
       attributeId: z.string(),
     });
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     const response =
       await dataPreparationService.createDescriptorWithGivenState({
         token,
@@ -53,9 +53,8 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già pubblicato una nuova versione per quell'e-service che richiede un attributo {string} che {string} non possiede",
+  "{string} ha già pubblicato una nuova versione per quell'e-service che richiede un attributo {string} che {string} non possiede",
   async function (
-    role: Role,
     tenantType: TenantType,
     kind: AttributeKind,
     _consumer: TenantType
@@ -65,7 +64,7 @@ Given(
       eserviceId: z.string(),
     });
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
 
     const attributeId = await dataPreparationService.createAttribute(
       token,

--- a/features/attribute/attribute-listing.feature
+++ b/features/attribute/attribute-listing.feature
@@ -5,7 +5,7 @@ Feature: Listing attributi
   @attribute_listing1
   Scenario Outline: Restituisce gli attributi disponibili
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA1" ha già creato 5 attributi "DECLARED"
+    Given "PA1" ha già creato 5 attributi "DECLARED"
     When l'utente richiede una operazione di listing degli attributi
     Then si ottiene status code 200 e la lista di 5 attributi
 
@@ -30,37 +30,37 @@ Feature: Listing attributi
   @attribute_listing2
   Scenario Outline: A fronte di 20 attributi in db e una richiesta di 12 attributi, restituisce solo i primi 12 risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 20 attributi "DECLARED"
+    Given "PA1" ha già creato 20 attributi "DECLARED"
     When l'utente richiede una operazione di listing degli attributi limitata ai primi 12 attributi
     Then si ottiene status code 200 e la lista di 12 attributi
 
   @attribute_listing3
   Scenario Outline: A fronte di 15 attribute in db e un offset di 12, restituisce solo 3 risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 15 attributi "DECLARED"
+    Given "PA1" ha già creato 15 attributi "DECLARED"
     When l'utente richiede una operazione di listing degli attributi con offset 12
     Then si ottiene status code 200 e la lista di 3 attributi
 
   @attribute_listing4
   Scenario Outline: A fronte di 5 attributi in db dei quali 3 certificati, 2 verificati e 1 dichiarato, restituisce solo i 3 certificati e i 2 verificati
     Given l'utente è un "admin" di "PA2"
-    Given un "admin" di "PA2" ha già creato 3 attributi "CERTIFIED"
-    Given un "admin" di "PA2" ha già creato 2 attributi "VERIFIED"
-    Given un "admin" di "PA2" ha già creato 1 attributo "DECLARED"
+    Given "PA2" ha già creato 3 attributi "CERTIFIED"
+    Given "PA2" ha già creato 2 attributi "VERIFIED"
+    Given "PA2" ha già creato 1 attributo "DECLARED"
     When l'utente richiede una operatione di listing degli attributi filtrando per tipo "certificato" e "verificato"
     Then si ottiene status code 200 e la lista di 5 attributi
 
   @attribute_listing5
   Scenario Outline: Restituisce gli attributi in db che contengono la keyword "test" all'interno del nome con ricerca case insensitive
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 3 attributi "DECLARED"
-    Given un "admin" di "PA1" ha già creato un attributo "DECLARED" con nome che contiene "test"
+    Given "PA1" ha già creato 3 attributi "DECLARED"
+    Given "PA1" ha già creato un attributo "DECLARED" con nome che contiene "test"
     When l'utente richiede una operazione di listing degli attributi filtrando per keyword "test" all'interno del nome
     Then si ottiene status code 200 e la lista di 1 attributo
 
   @attribute_listing6
   Scenario Outline: Restituisce un insieme vuoto di attributi per una ricerca che non porta risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 3 attributi "DECLARED"
+    Given "PA1" ha già creato 3 attributi "DECLARED"
     When l'utente richiede una operazione di listing degli attributi filtrando per keyword "unknown" all'interno del nome
     Then si ottiene status code 200 e la lista di 0 attributi

--- a/features/attribute/attribute-read.feature
+++ b/features/attribute/attribute-read.feature
@@ -5,7 +5,7 @@ Feature: Lettura singolo attributo
   @attribute_read1
   Scenario Outline: Alla richiesta di un attributo presente in DB, restituisce il risultato
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA1" ha già creato 1 attributo "DECLARED"
+    Given "PA1" ha già creato 1 attributo "DECLARED"
     When l'utente richiede una operazione di lettura di quel attributo
     Then si ottiene status code 200
 

--- a/features/attribute/step_definitions/attribute-common-steps.ts
+++ b/features/attribute/step_definitions/attribute-common-steps.ts
@@ -7,15 +7,14 @@ import { AttributeKind } from "../../../api/models";
 import { dataPreparationService } from "../../../services/data-preparation.service";
 
 Given(
-  "un {string} di {string} ha già creato {int} attribut(i)(o) {string}",
+  "{string} ha già creato {int} attribut(i)(o) {string}",
   async function (
-    role: Role,
     tenantType: TenantType,
     count: number,
     attributeKind: AttributeKind
   ) {
     assertContextSchema(this);
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
 
     const promises = [];
 
@@ -34,15 +33,14 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già creato un attributo {string} con nome che contiene {string}",
+  "{string} ha già creato un attributo {string} con nome che contiene {string}",
   async function (
-    role: Role,
     tenantType: TenantType,
     attributeKind: AttributeKind,
     keyword: string
   ) {
     assertContextSchema(this);
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     await dataPreparationService.createAttribute(
       token,
       attributeKind,

--- a/features/catalog/descriptor-activation.feature
+++ b/features/catalog/descriptor-activation.feature
@@ -5,7 +5,7 @@ Feature: Attivazione di un descrittore
   @descriptor_activation1
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato SUSPENDED, all'attivazione del descrittore, torna allo stato PUBLISHED
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "SUSPENDED"
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "SUSPENDED"
     When l'utente attiva il descrittore di quell'e-service
     Then si ottiene status code <risultato>
 
@@ -25,7 +25,7 @@ Feature: Attivazione di un descrittore
   @descriptor_activation2
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale non si trova in stato SUSPENDED, alla riattivazione del descrittore, si ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>"
     When l'utente attiva il descrittore di quell'e-service
     Then si ottiene status code 400
 

--- a/features/catalog/descriptor-deletion.feature
+++ b/features/catalog/descriptor-deletion.feature
@@ -5,7 +5,7 @@ Feature: Cancellazione di un descrittore
   @descriptor_deletion1
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato DRAFT, la richiesta di cancellazione del descrittore cancella contestualmente anche l'e-service del quale fa parte
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "DRAFT"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "DRAFT"
     When l'utente cancella il descrittore di quell'e-service
     Then si ottiene status code 204
     Then il descrittore è stato cancellato, ma l'eservice no
@@ -13,8 +13,8 @@ Feature: Cancellazione di un descrittore
   @descriptor_deletion2
   Scenario Outline: Per un e-service che ha più di un descrittore, l’ultimo dei quali è in stato DRAFT, la richiesta di cancellazione del descrittore cancella solo il descrittore stesso e non l’e-service del quale fa parte né nessuno degli altri descrittori dell’e-service
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "PUBLISHED"
-    Given un "admin" di "PA1" ha già creato una versione in "DRAFT" per quell'e-service
+    Given "PA1" ha già creato un e-service con un descrittore in stato "PUBLISHED"
+    Given "PA1" ha già creato una versione in "DRAFT" per quell'e-service
     When l'utente cancella il descrittore di quell'e-service
     Then si ottiene status code 204
     Then quell'e-service non è stato cancellato
@@ -22,7 +22,7 @@ Feature: Cancellazione di un descrittore
   @descriptor_deletion3
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato NON DRAFT (PUBLISHED, SUSPENDED, DEPRECATED, ARCHIVED), la richiesta di cancellazione del descrittore restituisce errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoVersione>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoVersione>"
     When l'utente cancella il descrittore di quell'e-service
     Then si ottiene status code 400
 

--- a/features/catalog/descriptor-draft-update.feature
+++ b/features/catalog/descriptor-draft-update.feature
@@ -5,7 +5,7 @@ Feature: Aggiornamento di un descrittore in bozza
   @descriptor_draft_update1
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato DRAFT, all’aggiornamento da parte di un utente autorizzato di alcuni parametri del descrittore, ben formattati, la bozza viene aggiornata correttamente
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT"
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT"
     When l'utente aggiorna alcuni parametri di quel descrittore
     Then si ottiene status code <risultato>
 
@@ -25,7 +25,7 @@ Feature: Aggiornamento di un descrittore in bozza
   @descriptor_draft_update2
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato NON DRAFT (PUBLISHED, SUSPENDED, DEPRECATED, ARCHIVED), all’aggiornamento di alcuni parametri del descrittore, ben formattati, l’aggiornamento della bozza restituisce errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoVersione>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoVersione>"
     When l'utente aggiorna alcuni parametri di quel descrittore
     Then si ottiene status code 400
 

--- a/features/catalog/descriptor-publication.feature
+++ b/features/catalog/descriptor-publication.feature
@@ -5,8 +5,8 @@ Feature: Pubblicazione di un descrittore
   @descriptor_publication1
   Scenario Outline: Per un e-service creato in modalità "DELIVER" che ha un solo descrittore, il quale è in stato DRAFT, con tutti i parametri richiesti inseriti e formattati correttamente, alla richiesta di pubblicazione, la bozza viene pubblicata correttamente
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT"
-    Given un "admin" di "<ente>" ha già caricato un'interfaccia per quel descrittore
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT"
+    Given "<ente>" ha già caricato un'interfaccia per quel descrittore
     When l'utente pubblica quel descrittore
     Then si ottiene status code <risultato>
 
@@ -26,7 +26,7 @@ Feature: Pubblicazione di un descrittore
   @descriptor_publication2
   Scenario Outline: Per un e-service creato in modalità "DELIVER" che ha un solo descrittore, il quale non è in stato DRAFT, alla richiesta di pubblicazione, si ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoVersione>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoVersione>"
     When l'utente pubblica quel descrittore
     Then si ottiene status code 400
 
@@ -40,16 +40,16 @@ Feature: Pubblicazione di un descrittore
   @descriptor_publication3
   Scenario Outline: Per un e-service creato in modalità "RECEIVE" che ha un solo descrittore, il quale è in stato DRAFT, con tutti i parametri richiesti inseriti e formattati correttamente, senza nessuna analisi del rischio inserita, alla richiesta di pubblicazione, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
-    Given un "admin" di "PA1" ha già caricato un'interfaccia per quel descrittore
+    Given "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
+    Given "PA1" ha già caricato un'interfaccia per quel descrittore
     When l'utente pubblica quel descrittore
     Then si ottiene status code 400
 
   @descriptor_publication4
   Scenario Outline: Per un e-service creato in modalità "RECEIVE" che ha un solo descrittore, il quale è in stato DRAFT, con tutti i parametri richiesti inseriti e formattati correttamente, e con un’analisi del rischio compilata solo parzialmente, alla richiesta di pubblicazione, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
-    Given un "admin" di "PA1" ha già caricato un'interfaccia per quel descrittore
+    Given "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
+    Given "PA1" ha già caricato un'interfaccia per quel descrittore
     Given l'utente ha compilato parzialmente l'analisi del rischio
     When l'utente pubblica quel descrittore
     Then si ottiene status code 400

--- a/features/catalog/descriptor-published-update.feature
+++ b/features/catalog/descriptor-published-update.feature
@@ -5,7 +5,7 @@ Feature: Aggiornamento di un descrittore già pubblicato
   @descriptor_published_update1
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato DRAFT, all’aggiornamento da parte di un utente autorizzato della durata del voucher e delle soglie di carico del descrittore, la bozza viene aggiornata correttamente
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT"
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT"
     When l'utente aggiorna la durata del voucher e le soglie di carico di quel descrittore
     Then si ottiene status code <risultato>
 
@@ -25,7 +25,7 @@ Feature: Aggiornamento di un descrittore già pubblicato
   @descriptor_published_update2
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato PUBLISHED, SUSPENDED o DEPRECATED, all'aggiornamento della durata del voucher e delle soglie di carico, l'operazione va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoVersione>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoVersione>"
     When l'utente aggiorna la durata del voucher e le soglie di carico di quel descrittore
     Then si ottiene status code <risultato>
 

--- a/features/catalog/descriptor-read-consumer.feature
+++ b/features/catalog/descriptor-read-consumer.feature
@@ -5,7 +5,7 @@ Feature: Lettura di un descrittore lato fruitore
   @descriptor_read_consumer1
   Scenario Outline: Per un e-service precedentemente creato da qualsiasi ente, il quale ha un solo descrittore in stato NON DRAFT (PUBLISHED, SUSPENDED, DEPRECATED, ARCHIVED), la richiesta per ottenere i dettagli della versione di e-service va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA2" ha già creato un e-service con un descrittore in stato "<statoVersione>"
+    Given "PA2" ha già creato un e-service con un descrittore in stato "<statoVersione>"
     When l'utente fruitore richiede la lettura di quel descrittore
     Then si ottiene status code 200
 
@@ -36,6 +36,6 @@ Feature: Lettura di un descrittore lato fruitore
   @descriptor_read_consumer2
   Scenario Outline: Per un e-service precedentemente creato da qualsiasi ente, il quale ha un solo descrittore in stato DRAFT, la richiesta per ottenere i dettagli della versione di e-service restituisce errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service con un descrittore in stato "DRAFT"
+    Given "PA2" ha già creato un e-service con un descrittore in stato "DRAFT"
     When l'utente fruitore richiede la lettura di quel descrittore
     Then si ottiene status code 404

--- a/features/catalog/descriptor-read-producer.feature
+++ b/features/catalog/descriptor-read-producer.feature
@@ -5,7 +5,7 @@ Feature: Lettura di un descrittore lato erogatore
   @descriptor_read_producer1
   Scenario Outline: Per un e-service precedentemente creato dall’ente, il quale ha un solo descrittore in qualsiasi stato (DRAFT, PUBLISHED, SUSPENDED, DEPRECATED, ARCHIVED), la richiesta per ottenere i dettagli della versione di e-service, da parte di un utente autorizzato, va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "<statoVersione>"
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "<statoVersione>"
     When l'utente richiede la lettura di quel descrittore
     Then si ottiene status code <risultato>
 
@@ -32,7 +32,7 @@ Feature: Lettura di un descrittore lato erogatore
   @descriptor_read_producer2
   Scenario Outline: Per un e-service precedentemente creato da un altro ente, il quale ha un solo descrittore in qualsiasi stato (DRAFT, PUBLISHED, SUSPENDED, DEPRECATED, ARCHIVED), la richiesta per ottenere i dettagli della versione di e-service restituisce errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato un e-service con un descrittore in stato "<statoVersione>"
+    Given "PA2" ha già creato un e-service con un descrittore in stato "<statoVersione>"
     When l'utente richiede la lettura di quel descrittore
     Then si ottiene status code <risultato>
 

--- a/features/catalog/descriptor-suspension.feature
+++ b/features/catalog/descriptor-suspension.feature
@@ -5,7 +5,7 @@ Feature: Sospensione di un descrittore
   @descriptor_suspension1
   Scenario Outline: Per un e-service che ha un descrittore in stato PUBLISHED o DEPRECATED, alla richiesta di sospensione da parte di un utente autorizzato, la sospensione va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "<statoVersione>"
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "<statoVersione>"
     When l'utente sospende quel descrittore
     Then si ottiene status code <risultato>
 
@@ -27,7 +27,7 @@ Feature: Sospensione di un descrittore
   @descriptor_suspension2
   Scenario Outline: Per un e-service che ha un descrittore in stato ARCHIVED, DRAFT o SUSPENDED, alla richiesta di sospensione, si ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoVersione>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoVersione>"
     When l'utente sospende quel descrittore
     Then si ottiene status code 400
 

--- a/features/catalog/document-delete.feature
+++ b/features/catalog/document-delete.feature
@@ -5,7 +5,7 @@ Feature: Cancellazione di un documento
   @document_delete1
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato DRAFT, alla richiesta di cancellazione di un documento precedentemente caricato, l'operazione va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT" e un documento già caricato
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT" e un documento già caricato
     When l'utente cancella quel documento
     Then si ottiene status code <risultato>
 
@@ -25,7 +25,7 @@ Feature: Cancellazione di un documento
   @document_delete2
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato NON DRAFT (PUBLISHED, SUSPENDED, DEPRECATED, ARCHIVED), alla richiesta di cancellazione di un documento precedentemente caricato, si ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>" e un documento già caricato
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>" e un documento già caricato
     When l'utente cancella quel documento
     Then si ottiene status code 400
 

--- a/features/catalog/document-read.feature
+++ b/features/catalog/document-read.feature
@@ -5,7 +5,7 @@ Feature: Lettura di un documento
   @document_read1
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato DRAFT, alla richiesta di recupero di un documento precedentemente caricato da parte di un utente autorizzato (api o admin dell’ente erogatore di quell’e-service), l'operazione va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT" e un documento già caricato
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT" e un documento già caricato
     When l'utente richiede il documento
     Then si ottiene status code <risultato>
 
@@ -25,7 +25,7 @@ Feature: Lettura di un documento
   @document_read2
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato NON DRAFT (PUBLISHED, SUSPENDED, DEPRECATED, ARCHIVED), alla richiesta di recupero di un documento precedentemente caricato da parte di un utente autenticato (qualunque livello di permesso di qualunque ente), l'operazione va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>" e un documento già caricato
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>" e un documento già caricato
     When l'utente richiede il documento
     Then si ottiene status code 200
 

--- a/features/catalog/document-update.feature
+++ b/features/catalog/document-update.feature
@@ -5,7 +5,7 @@ Feature: Aggiornamento del nome di un documento
   @document_update1
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato DRAFT, e che ha almeno un documento già caricato, alla richiesta di aggiornamento del nome, l'operazione va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT" e un documento già caricato
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "DRAFT" e un documento già caricato
     When l'utente aggiorna il nome di quel documento
     Then si ottiene status code <risultato>
 
@@ -25,7 +25,7 @@ Feature: Aggiornamento del nome di un documento
   @document_update2
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato NON DRAFT (PUBLISHED, SUSPENDED, DEPRECATED, ARCHIVED), e che ha almeno un documento già caricato, alla richiesta di aggiornamento del nome, si ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>" e un documento già caricato
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>" e un documento già caricato
     When l'utente aggiorna il nome di quel documento
     Then si ottiene status code 400
 

--- a/features/catalog/document-upload.feature
+++ b/features/catalog/document-upload.feature
@@ -5,7 +5,7 @@ Feature: Caricamento di un documento di interfaccia
   @document_upload1
   Scenario Outline: Per un e-service che eroga con una determinata tecnologia e che ha un solo descrittore, il quale è in stato DRAFT, alla richiesta di caricamento di un documento di interfaccia coerente con la tecnologia, da parte di un utente autorizzato, l'operazione avrà successo altrimenti restituirà errore.
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato DRAFT e tecnologia "REST"
+    Given "<ente>" ha già creato un e-service con un descrittore in stato DRAFT e tecnologia "REST"
     When l'utente carica un documento di interfaccia di tipo "yaml"
     Then si ottiene status code <risultato>
 
@@ -26,7 +26,7 @@ Feature: Caricamento di un documento di interfaccia
   @document_upload2
   Scenario Outline: Per un e-service che eroga con una determinata tecnologia e che ha un solo descrittore, il quale è in stato DRAFT, alla richiesta di caricamento di un documento di interfaccia coerente con la tecnologia, da parte di un utente autorizzato, l'operazione avrà successo altrimenti restituirà errore.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato DRAFT e tecnologia "<technology>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato DRAFT e tecnologia "<technology>"
     When l'utente carica un documento di interfaccia di tipo "<tipoFile>"
     Then si ottiene status code <risultato>
 
@@ -44,7 +44,7 @@ Feature: Caricamento di un documento di interfaccia
   @document_upload3
   Scenario Outline: Per un e-service che eroga con una determinata tecnologia e che ha un solo descrittore, il quale è in stato DRAFT, alla richiesta di caricamento di un documento di interfaccia coerente con la tecnologia, ma contenente il termine localhost, l'operazione restituirà errore.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato DRAFT e tecnologia "<technology>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato DRAFT e tecnologia "<technology>"
     When l'utente carica un documento di interfaccia di tipo "<tipoFile>" che contiene il termine localhost
     Then si ottiene status code 403
 
@@ -58,7 +58,7 @@ Feature: Caricamento di un documento di interfaccia
   @document_upload4
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato NON DRAFT, alla richiesta di caricamento di un documento di interfaccia, l'operazione restituirà errore.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>"
     When l'utente carica un documento di interfaccia di tipo "yaml"
     Then si ottiene status code 400
 
@@ -72,7 +72,7 @@ Feature: Caricamento di un documento di interfaccia
   @document_upload5
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato DRAFT, e per il quale è già stato caricato un documento di interfaccia, alla richiesta di caricamento di un nuovo documento di interfaccia, l’operazione restituirà errore.
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "DRAFT"
-    Given un "admin" di "PA1" ha già caricato un'interfaccia per quel descrittore
+    Given "PA1" ha già creato un e-service con un descrittore in stato "DRAFT"
+    Given "PA1" ha già caricato un'interfaccia per quel descrittore
     When l'utente carica un documento di interfaccia di tipo "yaml"
     Then si ottiene status code 400

--- a/features/catalog/e-service-catalog-listing.feature
+++ b/features/catalog/e-service-catalog-listing.feature
@@ -5,7 +5,7 @@ Feature: Listing catalogo e-services
   @catalog_listing1
   Scenario Outline: Restituisce gli e-service a catalogo
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "PA1" ha già creato 5 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA1" ha già creato 5 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     When l'utente richiede una operazione di listing sul catalogo
     Then si ottiene status code 200 e la lista di 5 e-services
 
@@ -30,29 +30,29 @@ Feature: Listing catalogo e-services
   @catalog_listing2
   Scenario Outline: A fronte di 20 e-service in db e una richiesta di 12 e-service, restituisce solo i primi 12 risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 19 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA1" ha già creato 19 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     When l'utente richiede una operazione di listing sul catalogo limitata ai primi 12 e-services
     Then si ottiene status code 200 e la lista di 12 e-services
 
   @catalog_listing3
   Scenario Outline: A fronte di 15 e-service in db e una richiesta di risultati a partire dal tredicesimo, vengono restituiti solo 3 e-service
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 15 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA1" ha già creato 15 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     When l'utente richiede una operazione di listing sul catalogo con offset 12
     Then si ottiene status code 200 e la lista di 3 e-services
 
   @catalog_listing4
   Scenario Outline: Restituisce gli e-service a catalogo erogati da almeno uno degli erogatori specifici
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato 2 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
-    Given un "admin" di "GSP" ha già creato 2 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA2" ha già creato 2 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "GSP" ha già creato 2 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     When l'utente richiede una operazione di listing degli e-services dell'erogatore "PA2"
     Then si ottiene status code 200 e la lista di 2 e-services
 
   @catalog_listing5
   Scenario Outline: Restituisce gli e-service a catalogo per i quali lo specifico fruitore ha almeno un agreement in stato ACTIVE
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato 3 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA2" ha già creato 3 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     And "PA1" ha un agreement attivo con un e-service di "PA2"
     When l'utente richiede la lista di e-services per i quali ha almeno un agreement attivo
     Then si ottiene status code 200 e la lista di 1 e-service
@@ -61,14 +61,14 @@ Feature: Listing catalogo e-services
   Scenario Outline: Restituisce gli e-service a catalogo che contengono la keyword "test" all'interno del nome,
   con ricerca case insensitive
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 2 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
-    Given un "admin" di "PA1" ha già creato e pubblicato un e-service contenente la keyword "test"
+    Given "PA1" ha già creato 2 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA1" ha già creato e pubblicato un e-service contenente la keyword "test"
     When l'utente richiede una operazione di listing sul catalogo filtrando per la keyword "test"
     Then si ottiene status code 200 e la lista di 1 e-service
 
   @catalog_listing7
   Scenario Outline: Restituisce un insieme vuoto di e-service a catalogo per una ricerca che non porta risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA2" ha già creato 10 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA2" ha già creato 10 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     When l'utente richiede una operazione di listing sul catalogo filtrando per la keyword "unknown"
     Then si ottiene status code 200 e la lista di 0 e-services

--- a/features/catalog/e-service-clone.feature
+++ b/features/catalog/e-service-clone.feature
@@ -5,8 +5,8 @@ Feature: Clonazione di un e-service
   @eservice_cloning1
   Scenario Outline: Per un e-service che ha 2 descrittori, l’ultimo dei quali è in stato PUBLISHED/SUSPENDED, alla richiesta di clonazione, viene creato un nuovo e-service che ha un solo descrittore in stato DRAFT. Sia il nuovo e-service che il suo descrittore hanno esattamente le stesse caratteristiche dell’e-service e descrittore di partenza (ad eccezione del nome dell’e-service al quale viene aggiunto un “ - clone” alla fine;
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "PUBLISHED"
-    Given un "admin" di "<ente>" ha già creato una versione in "<statoDescrittore>" per quell'e-service
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "PUBLISHED"
+    Given "<ente>" ha già creato una versione in "<statoDescrittore>" per quell'e-service
     When l'utente clona quell'e-service
     Then si ottiene status code <risultato>
 

--- a/features/catalog/e-service-consumers-download.feature
+++ b/features/catalog/e-service-consumers-download.feature
@@ -5,7 +5,7 @@ Feature: Download dei fruitori di un e-service
   @eservice_consumers1
   Scenario Outline: Per un e-service precedentemente creato e pubblicato, è possibile scaricare il file contenente l'elenco dei fruitori
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service con un descrittore in stato "PUBLISHED"
+    Given "<ente>" ha già creato un e-service con un descrittore in stato "PUBLISHED"
     Given "GSP" ha un agreement attivo con quell'e-service
     Given "PA2" ha un agreement attivo con quell'e-service
     When l'utente richiede una operazione di download dei fruitori di quell'e-service

--- a/features/catalog/e-service-delete.feature
+++ b/features/catalog/e-service-delete.feature
@@ -5,7 +5,7 @@ Feature: Cancellazione di un e-service
   @eservice_delete1
   Scenario Outline: Per un e-service precedentemente creato, il quale non ha descrittori, la cancellazione dell'e-service avviene correttamente per i ruoli autorizzati
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service senza descrittore
+    Given "<ente>" ha già creato un e-service senza descrittore
     When l'utente cancella quell'e-service
     Then si ottiene status code <risultato>
 
@@ -25,7 +25,7 @@ Feature: Cancellazione di un e-service
   @eservice_delete2
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in qualsiasi stato NON DRAFT (PUBLISHED, SUSPENDED, DEPRECATED, ARCHIVED), la cancellazione dell'e-service restituisce errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>"
     When l'utente cancella quell'e-service
     Then si ottiene status code 409
 
@@ -40,7 +40,7 @@ Feature: Cancellazione di un e-service
   @eservice_delete3
   Scenario Outline: Per un e-service che ha un solo descrittore, il quale è in stato DRAFT, la cancellazione dell'e-service va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "DRAFT"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "DRAFT"
     When l'utente cancella quell'e-service
     Then si ottiene status code 204
 

--- a/features/catalog/e-service-producer-listing.feature
+++ b/features/catalog/e-service-producer-listing.feature
@@ -5,8 +5,8 @@ Feature: Listing e-services lato erogatore
   @producer_listing1
   Scenario Outline: Restituisce gli e-service erogati dall’ente
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato 5 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
-    Given un "admin" di "PA2" ha già creato 5 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "<ente>" ha già creato 5 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA2" ha già creato 5 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     When l'utente richiede una operazione di listing sui propri e-services erogati
     Then si ottiene status code 200 e la lista di <risultati> e-services
 
@@ -26,21 +26,21 @@ Feature: Listing e-services lato erogatore
   @producer_listing2
   Scenario Outline: A fronte di 20 e-service in db, restituisce solo i primi 12 risultati di e-service
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 19 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA1" ha già creato 19 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     When l'utente richiede una operazione di listing sui propri e-services erogati limitata ai primi 12 e-services
     Then si ottiene status code 200 e la lista di 12 e-services
 
   @producer_listing3
   Scenario Outline: A fronte di 15 e-service in db e una richiesta di offset 12, restituisce solo 3 risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 14 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA1" ha già creato 14 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     When l'utente richiede una operazione di listing sui propri e-services con offset 12
     Then si ottiene status code 200 e la lista di 3 e-services
 
   @producer_listing4 @wait_for_fix @IMN-261
   Scenario Outline: Restituisce gli e-service erogati dall’ente fruiti da almeno uno dei fruitori specifici
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 2 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA1" ha già creato 2 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     Given "PA1" ha un agreement attivo con un e-service di "PA1"
     Given "PA2" ha un agreement attivo con un e-service di "PA1"
     When l'utente richiede una operazione di listing sui propri e-services fruiti da "PA2"
@@ -49,14 +49,14 @@ Feature: Listing e-services lato erogatore
   @producer_listing5
   Scenario Outline: Restituisce gli e-service erogati dall’ente che contengono la keyword "test" all'interno del nome, con ricerca case insensitive
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 2 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
-    Given un "admin" di "PA1" ha già creato e pubblicato un e-service contenente la keyword "test"
+    Given "PA1" ha già creato 2 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA1" ha già creato e pubblicato un e-service contenente la keyword "test"
     When l'utente richiede una operazione di listing sui propri e-services filtrando per la keyword "test"
     Then si ottiene status code 200 e la lista di 1 e-service
 
   @producer_listing6
   Scenario Outline: Restituisce un insieme vuoto di e-service a catalogo per una ricerca che non porta risultati
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato 10 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
+    Given "PA1" ha già creato 10 e-services in catalogo in stato PUBLISHED o SUSPENDED e 1 in stato DRAFT
     When l'utente richiede una operazione di listing sui propri e-services filtrando per la keyword "unknown"
     Then si ottiene status code 200 e la lista di 0 e-services

--- a/features/catalog/e-service-read.feature
+++ b/features/catalog/e-service-read.feature
@@ -5,7 +5,7 @@ Feature: Lettura di un e-service
   @eservice_read1
   Scenario Outline: Per un e-service precedentemente creato dall’ente, il quale non ha descrittori, la richiesta per ottenere i dettagli dell'e-service va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service senza descrittore
+    Given "<ente>" ha già creato un e-service senza descrittore
     When l'utente richiede la lettura di quell'e-service
     Then si ottiene status code <risultato>
 

--- a/features/catalog/e-service-risk-analysis-addition.feature
+++ b/features/catalog/e-service-risk-analysis-addition.feature
@@ -5,7 +5,7 @@ Feature: Aggiunta di un'analisi del rischio ad un e-service
   @eservice_risk_analysis_addition1
   Scenario Outline: Per un e-service creato in modalità "RECEIVE", il quale non ha descrittori, è possibile inserire una nuova analisi del rischio. L'analisi del rischio deve essere ben formattata ma non necessariamente completamente compilata. La richiesta va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service in modalità "RECEIVE" senza descrittore
+    Given "<ente>" ha già creato un e-service in modalità "RECEIVE" senza descrittore
     When l'utente aggiunge un'analisi del rischio
     Then si ottiene status code <risultato>
 
@@ -25,48 +25,48 @@ Feature: Aggiunta di un'analisi del rischio ad un e-service
   @eservice_risk_analysis_addition2
   Scenario Outline: Per un e-service creato in modalità "RECEIVE", il quale ha un solo descrittore in stato DRAFT, è possibile inserire una nuova analisi del rischio. L'analisi del rischio deve essere ben formattata ma non necessariamente completamente compilata. La richiesta va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
+    Given "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
     When l'utente aggiunge un'analisi del rischio
     Then si ottiene status code 204
 
   @eservice_risk_analysis_addition3
   Scenario Outline: Per un e-service creato in modalità "DELIVER", il quale non ha descrittori, alla richiesta di inserimento di un'analisi del rischio, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "DELIVER" senza descrittore
+    Given "PA1" ha già creato un e-service in modalità "DELIVER" senza descrittore
     When l'utente aggiunge un'analisi del rischio
     Then si ottiene status code 400
 
   @eservice_risk_analysis_addition4
   Scenario Outline: Per un e-service creato in modalità "DELIVER", il quale ha un solo descrittore in stato DRAFT, alla richiesta di inserimento di un'analisi del rischio, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "DELIVER" con un descrittore in stato "DRAFT"
+    Given "PA1" ha già creato un e-service in modalità "DELIVER" con un descrittore in stato "DRAFT"
     When l'utente aggiunge un'analisi del rischio
     Then si ottiene status code 400
 
   @eservice_risk_analysis_addition5
   Scenario Outline: Per un e-service creato in modalità "RECEIVE", il quale non ha descrittori, alla richiesta di inserimento di un'analisi del rischio ben formattata e dell'ultima versione per quella tipologia di ente ma della tipologia errata, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "RECEIVE" senza descrittore
+    Given "PA1" ha già creato un e-service in modalità "RECEIVE" senza descrittore
     When l'utente aggiunge un'analisi del rischio non corretta per la tipologia di ente
     Then si ottiene status code 400
 
   @eservice_risk_analysis_addition6
   Scenario Outline: Per un e-service creato in modalità "RECEIVE", il quale ha un solo descrittore in stato DRAFT, alla richiesta di inserimento di un'analisi del rischio ben formattata e della versione corretta per quella tipologia di ente ma della tipologia errata, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
+    Given "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
     When l'utente aggiunge un'analisi del rischio non corretta per la tipologia di ente
     Then si ottiene status code 400
 
   @eservice_risk_analysis_addition7
   Scenario Outline: Per un e-service creato in modalità "RECEIVE", il quale non ha descrittori, alla richiesta di inserimento di un'analisi del rischio ben formattata e della tipologia corretta per quella tipologia di ente ma in una versione che non è la “latest”, l’ultima disponibile, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "RECEIVE" senza descrittore
+    Given "PA1" ha già creato un e-service in modalità "RECEIVE" senza descrittore
     When l'utente aggiunge un'analisi del rischio con versione template non aggiornata
     Then si ottiene status code 400
 
   @eservice_risk_analysis_addition8
   Scenario Outline: Per un e-service creato in modalità "RECEIVE", il quale ha un solo descrittore in stato DRAFT, alla richiesta di inserimento di un'analisi del rischio ben formattata e della tipologia corretta per quella tipologia di ente ma in una versione che non è la “latest”, l’ultima disponibile, ottiene un errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
+    Given "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
     When l'utente aggiunge un'analisi del rischio con versione template non aggiornata
     Then si ottiene status code 400

--- a/features/catalog/e-service-risk-analysis-delete.feature
+++ b/features/catalog/e-service-risk-analysis-delete.feature
@@ -5,8 +5,8 @@ Feature: Cancellazione di un'analisi del rischio ad un e-service
   @eservice_risk_analysis_delete1
   Scenario Outline: Per un e-service creato in modalità "RECEIVE", il quale non ha descrittori, è possibile cancellare un'analisi del rischio precedentemente creata. L'analisi del rischio deve essere ben formattata ma non necessariamente completamente compilata. La richiesta va a buon fine se effettuata da un utente autorizzato
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service in modalità "RECEIVE" senza descrittore
-    Given un "admin" di "<ente>" ha già aggiunto un'analisi del rischio a quell'e-service
+    Given "<ente>" ha già creato un e-service in modalità "RECEIVE" senza descrittore
+    Given "<ente>" ha già aggiunto un'analisi del rischio a quell'e-service
     When l'utente cancella quell'analisi del rischio di quell'e-service
     Then si ottiene status code <risultato>
 
@@ -26,7 +26,7 @@ Feature: Cancellazione di un'analisi del rischio ad un e-service
   @eservice_risk_analysis_delete2
   Scenario Outline: Per un e-service creato in modalità "RECEIVE", il quale ha un solo descrittore in stato DRAFT, è possibile cancellare un'analisi del rischio precedentemente creata. L'analisi del rischio deve essere ben formattata ma non necessariamente completamente compilata. La richiesta va a buon fine se effettuata da un utente autorizzato
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
-    Given un "admin" di "PA1" ha già aggiunto un'analisi del rischio a quell'e-service
+    Given "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
+    Given "PA1" ha già aggiunto un'analisi del rischio a quell'e-service
     When l'utente cancella quell'analisi del rischio di quell'e-service
     Then si ottiene status code 204

--- a/features/catalog/e-service-risk-analysis-read.feature
+++ b/features/catalog/e-service-risk-analysis-read.feature
@@ -5,7 +5,7 @@ Feature: Lettura di un'analisi del rischio di un eservice
   @eservice_risk_analysis_read1
   Scenario Outline: Per un e-service precedentemente creato e pubblicato in modalità "RECEIVE", alla richiesta di lettura di una sua analisi del rischio, l'operazione va a buon fine
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "PUBLISHED"
+    Given "<ente>" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "PUBLISHED"
     When l'utente legge un'analisi del rischio di quell'e-service
     Then si ottiene status code 200
 

--- a/features/catalog/e-service-risk-analysis-update.feature
+++ b/features/catalog/e-service-risk-analysis-update.feature
@@ -5,8 +5,8 @@ Feature: Aggiornamento di un'analisi del rischio ad un e-service
   @eservice_risk_analysis_update1
   Scenario Outline: Per un e-service creato in modalità "RECEIVE", il quale non ha descrittori, è possibile aggiornare un'analisi del rischio precedentemente creata. L'analisi del rischio deve essere ben formattata ma non necessariamente completamente compilata. La richiesta va a buon fine se è un utente autorizzato
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service in modalità "RECEIVE" senza descrittore
-    Given un "admin" di "<ente>" ha già aggiunto un'analisi del rischio a quell'e-service
+    Given "<ente>" ha già creato un e-service in modalità "RECEIVE" senza descrittore
+    Given "<ente>" ha già aggiunto un'analisi del rischio a quell'e-service
     When l'utente aggiorna l'analisi del rischio di quell'e-service
     Then si ottiene status code <risultato>
 
@@ -26,7 +26,7 @@ Feature: Aggiornamento di un'analisi del rischio ad un e-service
   @eservice_risk_analysis_update2
   Scenario Outline: Per un e-service creato in modalità "RECEIVE", il quale ha un solo descrittore in stato DRAFT, è possibile aggiornare un'analisi del rischio precedentemente creata. L'analisi del rischio deve essere ben formattata ma non necessariamente completamente compilata. La richiesta va a buon fine
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
-    Given un "admin" di "PA1" ha già aggiunto un'analisi del rischio a quell'e-service
+    Given "PA1" ha già creato un e-service in modalità "RECEIVE" con un descrittore in stato "DRAFT"
+    Given "PA1" ha già aggiunto un'analisi del rischio a quell'e-service
     When l'utente aggiorna l'analisi del rischio di quell'e-service
     Then si ottiene status code 204

--- a/features/catalog/e-service-update.feature
+++ b/features/catalog/e-service-update.feature
@@ -5,7 +5,7 @@ Feature: Aggiornamento di un e-service
   @eservice_updating1
   Scenario Outline: Per un e-service precedentemente creato, il quale non ha descrittori, l'aggiornamento dei campi dell'e-service avviene correttamente
     Given l'utente è un "<ruolo>" di "<ente>"
-    Given un "admin" di "<ente>" ha già creato un e-service senza descrittore
+    Given "<ente>" ha già creato un e-service senza descrittore
     When l'utente aggiorna quell'e-service
     Then si ottiene status code <risultato>
 
@@ -25,14 +25,14 @@ Feature: Aggiornamento di un e-service
   @eservice_updating2
   Scenario Outline: Per un e-service precedentemente creato, il quale ha un solo descrittore in stato DRAFT, l’aggiornamento dei campi dell’e-service avviene correttamente
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "DRAFT"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "DRAFT"
     When l'utente aggiorna quell'e-service
     Then si ottiene status code 200
 
   @eservice_updating3
   Scenario Outline: Per un e-service precedentemente creato, il quale ha un solo descrittore in stato NON DRAFT (PUBLISHED, SUSPENDED, DEPRECATED, ARCHIVED), l’aggiornamento dei campi dell’e-service restituisce errore
     Given l'utente è un "admin" di "PA1"
-    Given un "admin" di "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>"
+    Given "PA1" ha già creato un e-service con un descrittore in stato "<statoDescrittore>"
     When l'utente aggiorna quell'e-service
     Then si ottiene status code 400
 

--- a/features/catalog/step_definitions/catalog-common-steps.ts
+++ b/features/catalog/step_definitions/catalog-common-steps.ts
@@ -3,7 +3,7 @@ import { Given, Then } from "@cucumber/cucumber";
 import { z } from "zod";
 import { EServiceDescriptorState } from "../../../api/models";
 import { dataPreparationService } from "../../../services/data-preparation.service";
-import { TenantType, Role } from "../../common-steps";
+import { TenantType } from "../../common-steps";
 import { assertContextSchema, getToken } from "../../../utils/commons";
 
 Then(
@@ -23,15 +23,14 @@ Then(
 );
 
 Given(
-  "un {string} di {string} ha già creato un e-service con un descrittore in stato {string}",
+  "{string} ha già creato un e-service con un descrittore in stato {string}",
   async function (
-    role: Role,
     tenantType: TenantType,
     descriptorState: EServiceDescriptorState
   ) {
     assertContextSchema(this);
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
 
     this.eserviceId = await dataPreparationService.createEService(token);
 
@@ -47,15 +46,14 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già creato un e-service con un descrittore in stato {string} e un documento già caricato",
+  "{string} ha già creato un e-service con un descrittore in stato {string} e un documento già caricato",
   async function (
-    role: Role,
     tenantType: TenantType,
     descriptorState: EServiceDescriptorState
   ) {
     assertContextSchema(this);
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
 
     this.eserviceId = await dataPreparationService.createEService(token);
 

--- a/features/catalog/step_definitions/descriptor-publication.ts
+++ b/features/catalog/step_definitions/descriptor-publication.ts
@@ -9,17 +9,17 @@ import {
 } from "../../../utils/commons";
 import { apiClient } from "../../../api";
 import { EServiceDescriptorState, EServiceMode } from "../../../api/models";
-import { TenantType, Role } from "../../common-steps";
+import { TenantType } from "../../common-steps";
 
 Given(
-  "un {string} di {string} ha già caricato un'interfaccia per quel descrittore",
-  async function (role: Role, tenantType: TenantType) {
+  "{string} ha già caricato un'interfaccia per quel descrittore",
+  async function (tenantType: TenantType) {
     assertContextSchema(this, {
       eserviceId: z.string(),
       descriptorId: z.string(),
     });
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
 
     await dataPreparationService.addInterfaceToDescriptor(
       token,
@@ -30,15 +30,14 @@ Given(
 );
 
 Given(
-  "un {string} di {string} ha già creato un e-service in modalità {string} con un descrittore in stato {string}",
+  "{string} ha già creato un e-service in modalità {string} con un descrittore in stato {string}",
   async function (
-    role: Role,
     tenantType: TenantType,
     mode: EServiceMode,
     descriptorState: EServiceDescriptorState
   ) {
     assertContextSchema(this);
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     this.eserviceId = await dataPreparationService.createEService(token, {
       mode,
     });

--- a/features/catalog/step_definitions/document-upload.ts
+++ b/features/catalog/step_definitions/document-upload.ts
@@ -8,18 +8,14 @@ import {
   uploadInterfaceDocument,
 } from "../../../utils/commons";
 import { dataPreparationService } from "../../../services/data-preparation.service";
-import { Role, TenantType } from "../../common-steps";
+import { TenantType } from "../../common-steps";
 
 Given(
-  "un {string} di {string} ha già creato un e-service con un descrittore in stato DRAFT e tecnologia {string}",
-  async function (
-    role: Role,
-    tenantType: TenantType,
-    technology: EServiceTechnology
-  ) {
+  "{string} ha già creato un e-service con un descrittore in stato DRAFT e tecnologia {string}",
+  async function (tenantType: TenantType, technology: EServiceTechnology) {
     assertContextSchema(this);
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
 
     const eserviceId = await dataPreparationService.createEService(token, {
       technology,

--- a/features/catalog/step_definitions/e-service-catalog-listing.ts
+++ b/features/catalog/step_definitions/e-service-catalog-listing.ts
@@ -8,19 +8,18 @@ import {
   getToken,
 } from "../../../utils/commons";
 import { dataPreparationService } from "../../../services/data-preparation.service";
-import { Role, TenantType, SessionTokens } from "../../common-steps";
+import { TenantType, SessionTokens } from "../../common-steps";
 
 Given(
-  "un {string} di {string} ha già creato {int} e-services in catalogo in stato PUBLISHED o SUSPENDED e {int} in stato DRAFT",
+  "{string} ha già creato {int} e-services in catalogo in stato PUBLISHED o SUSPENDED e {int} in stato DRAFT",
   async function (
-    role: Role,
     tenantType: TenantType,
     countEservices: number,
     countDraftEservices: number
   ) {
     assertContextSchema(this);
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     const SUSPENDED_ESERVICES = Math.floor(countEservices / 2);
     const PUBLISHED_ESERVICES = countEservices - SUSPENDED_ESERVICES;
     const DRAFT_ESERVICES = countDraftEservices;
@@ -229,11 +228,11 @@ When(
 );
 
 Given(
-  "un {string} di {string} ha già creato e pubblicato un e-service contenente la keyword {string}",
-  async function (role: Role, tenantType: TenantType, keyword: string) {
+  "{string} ha già creato e pubblicato un e-service contenente la keyword {string}",
+  async function (tenantType: TenantType, keyword: string) {
     assertContextSchema(this);
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     const eserviceName = `e-service-${this.TEST_SEED}-${keyword}`;
     this.eserviceId = await dataPreparationService.createEService(token, {
       name: eserviceName,

--- a/features/catalog/step_definitions/e-service-clone.ts
+++ b/features/catalog/step_definitions/e-service-clone.ts
@@ -7,13 +7,12 @@ import {
 } from "../../../utils/commons";
 import { apiClient } from "../../../api";
 import { EServiceDescriptorState } from "../../../api/models";
-import { Role, TenantType } from "../../common-steps";
+import { TenantType } from "../../common-steps";
 import { dataPreparationService } from "./../../../services/data-preparation.service";
 
 Given(
-  "un {string} di {string} ha già creato una versione in {string} per quell'e-service",
+  "{string} ha già creato una versione in {string} per quell'e-service",
   async function (
-    role: Role,
     tenantType: TenantType,
     descriptorState: EServiceDescriptorState
   ) {
@@ -21,7 +20,7 @@ Given(
       eserviceId: z.string(),
     });
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
 
     const { descriptorId } =
       await dataPreparationService.createDescriptorWithGivenState({

--- a/features/catalog/step_definitions/e-service-delete.ts
+++ b/features/catalog/step_definitions/e-service-delete.ts
@@ -7,14 +7,14 @@ import {
   getToken,
 } from "../../../utils/commons";
 import { apiClient } from "../../../api";
-import { Role, TenantType } from "../../common-steps";
+import { TenantType } from "../../common-steps";
 
 Given(
-  "un {string} di {string} ha già creato un e-service senza descrittore",
-  async function (role: Role, tenantType: TenantType) {
+  "{string} ha già creato un e-service senza descrittore",
+  async function (tenantType: TenantType) {
     assertContextSchema(this);
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
 
     this.eserviceId = await dataPreparationService.createEService(token);
   }

--- a/features/catalog/step_definitions/e-service-risk-analysis-addition.ts
+++ b/features/catalog/step_definitions/e-service-risk-analysis-addition.ts
@@ -9,14 +9,14 @@ import {
 } from "../../../utils/commons";
 import { EServiceMode } from "../../../api/models";
 import { apiClient } from "../../../api";
-import { Role, TenantType } from "../../common-steps";
+import { TenantType } from "../../common-steps";
 
 Given(
-  "un {string} di {string} ha già creato un e-service in modalità {string} senza descrittore",
-  async function (role: Role, tenantType: TenantType, mode: EServiceMode) {
+  "{string} ha già creato un e-service in modalità {string} senza descrittore",
+  async function (tenantType: TenantType, mode: EServiceMode) {
     assertContextSchema(this, { token: z.string() });
 
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
 
     this.eserviceId = await dataPreparationService.createEService(token, {
       mode,

--- a/features/catalog/step_definitions/e-service-risk-analysis-update.ts
+++ b/features/catalog/step_definitions/e-service-risk-analysis-update.ts
@@ -8,15 +8,15 @@ import {
 } from "../../../utils/commons";
 import { dataPreparationService } from "../../../services/data-preparation.service";
 import { apiClient } from "../../../api";
-import { Role, TenantType } from "../../common-steps";
+import { TenantType } from "../../common-steps";
 
 Given(
-  "un {string} di {string} ha già aggiunto un'analisi del rischio a quell'e-service",
-  async function (role: Role, tenantType: TenantType) {
+  "{string} ha già aggiunto un'analisi del rischio a quell'e-service",
+  async function (tenantType: TenantType) {
     assertContextSchema(this, {
       eserviceId: z.string(),
     });
-    const token = getToken(this.tokens, tenantType, role);
+    const token = getToken(this.tokens, tenantType, "admin");
     this.riskAnalysisId =
       await dataPreparationService.addRiskAnalysisToEService(
         token,


### PR DESCRIPTION
I've observed that `admin` is consistently used as the role in the `Given` steps. However, there are numerous steps with a parameterized role, which is redundant and clutters the test. 

For this reason, I refactored them to eliminate any mention of role by setting `admin` within the implementation.

These changes have been tested with `pnpm bun:test:ready` and they are functional.