### PR TITLE
PIN-9926: Create new workflow for interop-tracing e2e tests

### DIFF
--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -15,11 +15,6 @@ on:
           - tracing-dev
           - tracing-qa
           - tracing-vapt
-      kafkaPurgeTopics:
-        description: 'Purge Kafka topics'
-        required: true
-        default: false
-        type: boolean
       runDataPreparation:
         description: 'Data preparation (wipe + reload dump)'
         required: true
@@ -62,7 +57,6 @@ jobs:
     environment: ${{ github.event_name == 'schedule' && 'tracing-qa' || inputs.environment }}
     outputs:
       environment: ${{ steps.set_runtime_env.outputs.environment }}
-      kafkaPurgeTopics: ${{ steps.set_runtime_env.outputs.kafkaPurgeTopics }}
       runDataPreparation: ${{ steps.set_runtime_env.outputs.runDataPreparation }}
       runJSTests: ${{ steps.set_runtime_env.outputs.runJSTests }}
       runJavaTests: ${{ steps.set_runtime_env.outputs.runJavaTests }}
@@ -84,7 +78,6 @@ jobs:
         run: |
           if [[ "${{ steps.check_trigger.outputs.is_schedule }}" == "true" ]]; then
             environment="tracing-qa"
-            kafkaPurgeTopics="false"
             runDataPreparation="true"
             runJSTests="false"
             runJavaTests="true"
@@ -92,7 +85,6 @@ jobs:
             javaBranchName="develop"
           else
             environment="${{ inputs.environment }}"
-            kafkaPurgeTopics="${{ inputs.kafkaPurgeTopics }}"
             runDataPreparation="${{ inputs.runDataPreparation }}"
             runJSTests="false"
             runJavaTests="${{ inputs.runJavaTests }}"
@@ -102,7 +94,6 @@ jobs:
 
           {
             echo "environment=$environment"
-            echo "kafkaPurgeTopics=$kafkaPurgeTopics"
             echo "runDataPreparation=$runDataPreparation"
             echo "runJSTests=$runJSTests"
             echo "runJavaTests=$runJavaTests"
@@ -119,7 +110,6 @@ jobs:
           echo "- normalized environment: \`${{ vars.NORM_ENV }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- ref: \`${{ github.ref }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- plat-dep versions: \`${{ vars.PLAT_DEP_VERSIONS_URL }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- kafkaPurgeTopics: \`${{ steps.set_runtime_env.outputs.kafkaPurgeTopics }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- runDataPreparation: \`${{ steps.set_runtime_env.outputs.runDataPreparation }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- runJSTests: \`${{ steps.set_runtime_env.outputs.runJSTests }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- runJavaTests: \`${{ steps.set_runtime_env.outputs.runJavaTests }}\`" >> $GITHUB_STEP_SUMMARY
@@ -261,37 +251,6 @@ jobs:
           PGDATABASE: ${{ vars.TRACING_DB_NAME }}
         run: |
           $SCRIPTS_FOLDER/truncateSQLTables.sh
-
-      - name: Checkout Kafka tools
-        id: kafka_tools
-        if: ${{ always() && needs.workflow_context.outputs.kafkaPurgeTopics == 'true' }}
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          repository: pagopa/pdnd-interop-platform-deployment
-          path: plat-dep
-          sparse-checkout: kafka
-
-      - name: Purge Kafka topics
-        id: clean_kafka
-        if: ${{ always() && needs.workflow_context.outputs.kafkaPurgeTopics == 'true' }}
-        shell: bash
-        working-directory: plat-dep/kafka/scripts
-        env:
-            AWS_REGION: ${{ secrets.AWS_REGION}}
-            KAFKA_BROKERS: ${{ vars.KAFKA_BROKERS }}
-            TOPICS_PROPERTIES_PATH: ../topics/${{ vars.NORM_ENV }}/
-        run: |
-          set -euo pipefail
-
-          npm ci
-
-          export DOMAIN_TOPIC_PREFIX="${{ vars.EVENT_STORE_DOMAIN_TOPIC_PREFIX }}"
-          npm run kafka:deleteTopics
-
-          export DOMAIN_TOPIC_PREFIX="${{ vars.OUTBOUND_DOMAIN_TOPIC_PREFIX }}"
-          npm run kafka:deleteTopics
-
-          npm run kafka:createTopics
 
       - name: Restore Tracing Dump
         id: db_dump_restore

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -15,6 +15,11 @@ on:
           - tracing-dev
           - tracing-qa
           - tracing-vapt
+      kafkaPurgeTopics:
+        description: 'Purge Kafka topics'
+        required: true
+        default: false
+        type: boolean
       runDataPreparation:
         description: 'Data preparation (wipe + reload dump)'
         required: true

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -7,26 +7,16 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to run tests against'
+        description: 'Environment to run tracing e2e-tests against'
         required: true
-        default: es1-qa
+        default: tracing-qa
         type: choice
         options:
-          - es1-dev
-          - es1-qa
-          - es1-vapt
-      kafkaPurgeTopics:
-        description: 'Purge Kafka topics'
-        required: true
-        default: false
-        type: boolean
+          - tracing-dev
+          - tracing-qa
+          - tracing-vapt
       runDataPreparation:
         description: 'Data preparation (wipe + reload dump)'
-        required: true
-        default: false
-        type: boolean
-      runJSTests:
-        description: 'Run JavaScript test suite'
         required: true
         default: false
         type: boolean
@@ -34,7 +24,7 @@ on:
       runJavaTests:
         description: 'Run Java test in pn-b2b-client'
         required: true
-        default: false
+        default: true
         type: boolean
       javaTestSuite:
         description: 'Choose which Java test suite to run'
@@ -46,11 +36,6 @@ on:
         required: false
         default: main
         type: string
-      strictVersionCheck:
-        description: 'strictVersionCheck - DEPRECATED - will be removed in the future'
-        required: false
-        default: false
-        type: boolean
 
 
 defaults:
@@ -69,16 +54,15 @@ env:
 jobs:
   workflow_context:
     runs-on: ubuntu-22.04
-    environment: ${{ github.event_name == 'schedule' && 'es1-qa' || inputs.environment }}
+    environment: ${{ github.event_name == 'schedule' && 'tracing-qa' || inputs.environment }}
     outputs:
       environment: ${{ steps.set_runtime_env.outputs.environment }}
-      kafkaPurgeTopics: ${{ steps.set_runtime_env.outputs.kafkaPurgeTopics }}
+      kafkaPurgeTopics: "false"
       runDataPreparation: ${{ steps.set_runtime_env.outputs.runDataPreparation }}
       runJSTests: ${{ steps.set_runtime_env.outputs.runJSTests }}
       runJavaTests: ${{ steps.set_runtime_env.outputs.runJavaTests }}
       javaTestSuite: ${{ steps.set_runtime_env.outputs.javaTestSuite }}
       javaBranchName: ${{ steps.set_runtime_env.outputs.javaBranchName }}
-      strictVersionCheck: ${{ steps.set_runtime_env.outputs.strictVersionCheck }}
 
     steps:
       - name: Check trigger type
@@ -94,23 +78,21 @@ jobs:
         id: set_runtime_env
         run: |
           if [[ "${{ steps.check_trigger.outputs.is_schedule }}" == "true" ]]; then
-            environment="es1-qa"
-            kafkaPurgeTopics="true"
+            environment="tracing-qa"
+            kafkaPurgeTopics="false\"
             runDataPreparation="true"
             runJSTests="false"
             runJavaTests="true"
             javaTestSuite="NRTStandard"
             javaBranchName="develop"
-            strictVersionCheck="false"
           else
             environment="${{ inputs.environment }}"
             kafkaPurgeTopics="${{ inputs.kafkaPurgeTopics }}"
             runDataPreparation="${{ inputs.runDataPreparation }}"
-            runJSTests="${{ inputs.runJSTests }}"
+            runJSTests="false"
             runJavaTests="${{ inputs.runJavaTests }}"
             javaTestSuite="${{ inputs.javaTestSuite || 'NRTStandard' }}"
             javaBranchName="${{ inputs.javaBranchName || 'develop' }}"
-            strictVersionCheck="${{ inputs.strictVersionCheck }}"
           fi
 
           {
@@ -121,7 +103,6 @@ jobs:
             echo "runJavaTests=$runJavaTests"
             echo "javaTestSuite=$javaTestSuite"
             echo "javaBranchName=$javaBranchName"
-            echo "strictVersionCheck=$strictVersionCheck"
           } >> "$GITHUB_OUTPUT"
 
       - name: Print Inputs
@@ -139,7 +120,6 @@ jobs:
           echo "- runJavaTests: \`${{ steps.set_runtime_env.outputs.runJavaTests }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- javaTestSuite: \`${{ steps.set_runtime_env.outputs.javaTestSuite }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- javaBranchName: \`${{ steps.set_runtime_env.outputs.javaBranchName }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- strictVersionCheck: \`${{ steps.set_runtime_env.outputs.strictVersionCheck }}\`" >> $GITHUB_STEP_SUMMARY
 
   create_runner:
     name: Create Self-Hosted Runner
@@ -167,38 +147,9 @@ jobs:
           ecs_task_sec_group: ${{ secrets.SEC_GROUP_ID }}
           pat_token: ${{ secrets.BOT_TOKEN }}
 
-  svc_version_check:
-    name: Check Deployed Versions
-    needs: [workflow_context, create_runner]
-    if: ${{ needs.workflow_context.outputs.strictVersionCheck == 'true' }}
-    runs-on: [self-hosted, "run_id:${{ needs.workflow_context.outputs.environment }}-${{ github.run_id }}"]
-    environment: ${{ needs.workflow_context.outputs.environment }}
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-
-      - name: Get plat-dep versions
-        run: |
-          curl ${{ vars.PLAT_DEP_VERSIONS_URL }} -o images.yaml
-
-      - name: Set kubeconfig
-        run: |
-            aws eks update-kubeconfig --region ${{ secrets.AWS_REGION }} --name ${{ secrets.EKS_CLUSTER_NAME }}
-
-      - name: Check deployed versions
-        id: check_svc_version
-        shell: bash
-        env:
-            AWS_REGION: ${{ secrets.AWS_REGION}}
-            EKS_CLUSTER_NAME: ${{ secrets.EKS_CLUSTER_NAME}}
-            K8S_NAMESPACE: ${{ vars.K8S_NAMESPACE }}
-        run: |
-           $SCRIPTS_FOLDER/checkSvcVersion.sh images.yaml
-
   data_prep:
     name: Data Preparation
-    needs: [workflow_context, svc_version_check, create_runner]
+    needs: [workflow_context, create_runner]
     runs-on: [self-hosted, "run_id:${{ needs.workflow_context.outputs.environment }}-${{ github.run_id }}"]
     environment: ${{ needs.workflow_context.outputs.environment }}
     if: ${{ always() && needs.workflow_context.outputs.runDataPreparation == 'true' && needs.create_runner.result == 'success' }}
@@ -575,7 +526,7 @@ jobs:
 
   delete_runner:
     name: Delete Self-Hosted Runner
-    needs: [workflow_context, create_runner, svc_version_check, data_prep, run_js_test, run_java_test]
+    needs: [workflow_context, create_runner, data_prep, run_js_test, run_java_test]
     if: ${{ always() }}
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -1,4 +1,4 @@
-name: QA workflow
+name: Tracing QA workflow
 
 on:
   schedule:
@@ -57,7 +57,7 @@ jobs:
     environment: ${{ github.event_name == 'schedule' && 'tracing-qa' || inputs.environment }}
     outputs:
       environment: ${{ steps.set_runtime_env.outputs.environment }}
-      kafkaPurgeTopics: "false"
+      kafkaPurgeTopics: ${{ steps.set_runtime_env.outputs.kafkaPurgeTopics }}
       runDataPreparation: ${{ steps.set_runtime_env.outputs.runDataPreparation }}
       runJSTests: ${{ steps.set_runtime_env.outputs.runJSTests }}
       runJavaTests: ${{ steps.set_runtime_env.outputs.runJavaTests }}
@@ -79,7 +79,7 @@ jobs:
         run: |
           if [[ "${{ steps.check_trigger.outputs.is_schedule }}" == "true" ]]; then
             environment="tracing-qa"
-            kafkaPurgeTopics="false\"
+            kafkaPurgeTopics="false"
             runDataPreparation="true"
             runJSTests="false"
             runJavaTests="true"
@@ -322,7 +322,7 @@ jobs:
             KAFKA_BROKERS: ${{ vars.KAFKA_BROKERS }}
             TOPICS_PROPERTIES_PATH: ../topics/${{ vars.NORM_ENV }}/
         run: |
-          set -eou pipefail
+          set -euo pipefail
 
           npm ci
 

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -467,7 +467,7 @@ jobs:
 
   run_java_test:
     name: Run Java Cucumber Test Suite
-    if: ${{ always() && needs.workflow_context.outputs.runJSTests != 'true' && needs.workflow_context.outputs.runJavaTests == 'true' }}
+    if: ${{ always() && needs.create_runner.result == 'success' && needs.workflow_context.outputs.runJSTests != 'true' && needs.workflow_context.outputs.runJavaTests == 'true' }}
     needs: [workflow_context, create_runner, data_prep, run_js_test]
     runs-on: [self-hosted, "run_id:${{ needs.workflow_context.outputs.environment }}-${{ github.run_id }}"]
     environment: ${{ needs.workflow_context.outputs.environment }}

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -165,8 +165,6 @@ jobs:
       LOCAL_NOTIFICATION_CONFIG_DUMPS: "./db_dumps/notification_config"
       MAX_POLLING_TRIES: "${{ vars.MAX_POLLING_TRIES }}"
       POLLING_SLEEP_TIME: "${{ vars.POLLING_SLEEP_TIME }}"
-      DYNAMODB_PLATFORM_STATES_TABLE: ${{ vars.platformStatesTableName }}
-      DYNAMODB_TOKEN_GEN_STATES_TABLE: ${{ vars.tokenGenStatesTableName }}
     steps:
       - name: Checkout
         id: checkout
@@ -252,54 +250,15 @@ jobs:
             echo "PLATFORM_DATA_USERNAME=$PLATFORM_DATA_USERNAME" >> "$GITHUB_ENV"
             echo "PLATFORM_DATA_PASSWORD=$PLATFORM_DATA_PASSWORD" >> "$GITHUB_ENV"
 
-      - name: Truncate EventStore DB Tables
-        id: event_store_db_truncate
+      - name: Truncate Tracing DB Tables
+        id: tracing_db_truncate
         shell: bash
         env:
           PGUSER: ${{ env.PLATFORM_DATA_USERNAME }}
           PGPASSWORD: ${{ env.PLATFORM_DATA_PASSWORD }}
           PGHOST: ${{ env.PLATFORM_DATA_HOST }}
           PGPORT: ${{ env.PLATFORM_DATA_PORT }}
-          PGDATABASE: ${{ vars.EVENT_STORE_DB_NAME }}
-        run: |
-          $SCRIPTS_FOLDER/truncateSQLTables.sh
-
-      - name: Truncate ReadModel SQL DB Tables
-        id: read_model_sql_db_truncate
-        if: ${{ vars.READ_MODEL_SQL_DB_NAME != '' }}
-        shell: bash
-        env:
-          PGUSER: ${{ env.PLATFORM_DATA_USERNAME }}
-          PGPASSWORD: ${{ env.PLATFORM_DATA_PASSWORD }}
-          PGHOST: ${{ env.PLATFORM_DATA_HOST }}
-          PGPORT: ${{ env.PLATFORM_DATA_PORT }}
-          PGDATABASE: ${{ vars.READ_MODEL_SQL_DB_NAME }}
-        run: |
-          $SCRIPTS_FOLDER/truncateSQLTables.sh
-
-      - name: Truncate M2MEvents SQL DB Tables
-        id: m2m_events_sql_db_truncate
-        if: ${{ vars.M2M_EVENTS_SQL_DB_NAME != '' }}
-        shell: bash
-        env:
-          PGUSER: ${{ env.PLATFORM_DATA_USERNAME }}
-          PGPASSWORD: ${{ env.PLATFORM_DATA_PASSWORD }}
-          PGHOST: ${{ env.PLATFORM_DATA_HOST }}
-          PGPORT: ${{ env.PLATFORM_DATA_PORT }}
-          PGDATABASE: ${{ vars.M2M_EVENTS_SQL_DB_NAME }}
-        run: |
-          $SCRIPTS_FOLDER/truncateSQLTables.sh
-
-      - name: Truncate InAppNotification SQL DB Tables
-        id: in_app_notification_sql_db_truncate
-        if: ${{ vars.IN_APP_NOTIFICATION_SQL_DB_NAME != '' }}
-        shell: bash
-        env:
-          PGUSER: ${{ env.PLATFORM_DATA_USERNAME }}
-          PGPASSWORD: ${{ env.PLATFORM_DATA_PASSWORD }}
-          PGHOST: ${{ env.PLATFORM_DATA_HOST }}
-          PGPORT: ${{ env.PLATFORM_DATA_PORT }}
-          PGDATABASE: ${{ vars.IN_APP_NOTIFICATION_SQL_DB_NAME }}
+          PGDATABASE: ${{ vars.TRACING_DB_NAME }}
         run: |
           $SCRIPTS_FOLDER/truncateSQLTables.sh
 
@@ -334,27 +293,7 @@ jobs:
 
           npm run kafka:createTopics
 
-      - name: Purge Auth-Server DynamoDB Tables
-        id: purge_dynamodb
-        if: ${{ always() }}
-        env:
-          AWS_REGION: ${{ secrets.AWS_REGION}}
-          PLATFORM_STATES_TABLE_NAME: ${{ vars.PLATFORM_STATES_TABLE_NAME }}
-          TOKEN_GENERATION_TABLE_NAME: ${{ vars.TOKEN_GENERATION_TABLE_NAME }}
-        run: |
-          set -euo pipefail
-
-          echo "Starting ${PLATFORM_STATES_TABLE_NAME} DynamoDB table purge..."
-          ./scripts/purge-dynamodb-tables.sh  "${PLATFORM_STATES_TABLE_NAME}"
-          echo "${PLATFORM_STATES_TABLE_NAME} table purged successfully"
-
-          echo "Starting ${TOKEN_GENERATION_TABLE_NAME} DynamoDB table purge..."
-          ./scripts/purge-dynamodb-tables.sh  "${TOKEN_GENERATION_TABLE_NAME}"
-          echo "${TOKEN_GENERATION_TABLE_NAME} DynamoDB tables purged successfully"
-
-          echo "DynamoDB tables purged successfully"
-
-      - name: Restore Dump
+      - name: Restore Tracing Dump
         id: db_dump_restore
         shell: bash
         env:
@@ -362,7 +301,7 @@ jobs:
           PGPASSWORD: ${{ env.PLATFORM_DATA_PASSWORD }}
           PGHOST: ${{ env.PLATFORM_DATA_HOST }}
           PGPORT: ${{ env.PLATFORM_DATA_PORT }}
-          PGDATABASE: ${{ vars.EVENT_STORE_DB_NAME }}
+          PGDATABASE: ${{ vars.TRACING_DB_NAME }}
         run: |
           $SCRIPTS_FOLDER/restoreEventStore.sh
 

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -162,12 +162,7 @@ jobs:
       K8S_NAMESPACE: ${{ vars.K8S_NAMESPACE }}
       PLATFORM_DATA_HOST: ${{ vars.PLATFORM_DATA_HOST }}
       PLATFORM_DATA_PORT: 5432
-      LOCAL_ATTRIBUTE_REGISTRY_DUMPS: "./db_dumps/attribute_registry"
-      LOCAL_ATTRIBUTE_REGISTRY_TABLE_NAME: "events"
-      LOCAL_TENANT_DUMPS: "./db_dumps/tenant"
-      LOCAL_TENANT_JOURNAL_TABLE_NAME: "event_journal"
-      LOCAL_TENANT_TAG_TABLE_NAME: "event_tag"
-      LOCAL_NOTIFICATION_CONFIG_DUMPS: "./db_dumps/notification_config"
+      LOCAL_TRACING_DUMPS: "./db_dumps/tracing"
       MAX_POLLING_TRIES: "${{ vars.MAX_POLLING_TRIES }}"
       POLLING_SLEEP_TIME: "${{ vars.POLLING_SLEEP_TIME }}"
     steps:
@@ -308,7 +303,7 @@ jobs:
           PGPORT: ${{ env.PLATFORM_DATA_PORT }}
           PGDATABASE: ${{ vars.TRACING_DB_NAME }}
         run: |
-          $SCRIPTS_FOLDER/restoreEventStore.sh
+          $SCRIPTS_FOLDER/restoreTracing.sh
 
       - name: Scale up Deployments
         id: svc_scale_to_1

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -134,7 +134,7 @@ jobs:
     steps:
       - name: Start GitHub Runner
         id: start_runner
-        uses: pagopa/interop-github-runner-aws-create-action@main
+        uses: pagopa/interop-github-runner-aws-create-action@b1af978f506c221986d052d4c846e6fb534c46b6 # v1.8.0
         with:
           environment: ${{ needs.workflow_context.outputs.environment }}
           aws_region: ${{ secrets.AWS_REGION }}
@@ -538,7 +538,7 @@ jobs:
     steps:
       - name: Stop Github Runner
         id: stop_runner
-        uses: pagopa/interop-github-runner-aws-cleanup-action@main
+        uses: pagopa/interop-github-runner-aws-cleanup-action@61b18d1d3ee01be84fee72e2fa5836fc68f0a16e # v1.5.0
         with:
           environment: ${{ needs.workflow_context.outputs.environment }}
           aws_region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -1,5 +1,71 @@
 name: Tracing QA workflow
 
+# ======================================================================================
+# WORKFLOW DOCUMENTATION: TRACING QA
+# ======================================================================================
+# This workflow dynamically selects a GitHub Environment based on the 'environment' 
+# input or the cron schedule. All 'vars.*' and 'secrets.*' listed below are scoped 
+# to the selected environment in the GitHub repository settings.
+#
+# --------------------------------------------------------------------------------------
+# 1. ENVIRONMENT-SPECIFIC VARIABLES (vars)
+# --------------------------------------------------------------------------------------
+# These variables must be defined within the GitHub Environment UI.
+# Default values are not defined in this YAML but are managed in GitHub Settings.
+#
+# - K8S_NAMESPACE:                 The Kubernetes namespace for scaling and deployment ops.
+# - TRACING_STORE_HOST:            The hostname for the Tracing PostgreSQL database.
+# - TRACING_DB_NAME:               The name of the database to be truncated/restored.
+# - MAX_POLLING_TRIES:             Retry limit for K8s pod readiness and DB checks.
+# - POLLING_SLEEP_TIME:            Seconds to wait between polling attempts.
+# - DATA_PREPARATION_BUCKET:       S3 bucket name containing the database dumps.
+# - TRACING_DUMP_S3_PREFIX:         S3 path/prefix for tracing_store DB dumps.
+# - ECS_TASK_CONTAINER_NAME:       The container name used within the AWS ECS task.
+# - ECS_TASK_MAX_DURATION_SECONDS: Max lifecycle time for the ephemeral self-hosted runner.
+# - ENVIRONMENT:                   A string label passed to test suites (e.g., "dev" or "qa").
+# - REMOTE_WELLKNOWN_URL:          OIDC discovery URL for authentication tests.
+# - BFF_BASE_URL:                  The base URL for the Backend-for-Frontend service.
+# - ST_VERBOSE_MODE:               Boolean flag to enable/disable verbose test logging.
+# - TENANTS_IDS_FILE_PATH:         Path to the JSON/data file containing test tenant IDs.
+# - CLIENT_ASSERTION_JWT_AUDIENCE: The 'aud' claim required for JWT client assertions.
+# - NORM_ENV:                      A normalized environment name used for summary reporting.
+# - PLAT_DEP_VERSIONS_URL:         Reference URL for platform dependency versions.
+#
+# --------------------------------------------------------------------------------------
+# 2. ENVIRONMENT-SPECIFIC SECRETS (secrets)
+# --------------------------------------------------------------------------------------
+# - AWS_REGION:                    AWS Region for EKS, S3, and Secrets Manager.
+# - IAM_ROLE_ARN:                  The ARN of the role assumed by the ECS runner.
+# - ECS_CLUSTER_NAME:              The ECS cluster where the runner is spawned.
+# - ECS_TASK_DEFINITION:           The task definition ARN for the self-hosted runner.
+# - SUBNET_ID:                     VPC Subnet ID for the ECS task.
+# - SEC_GROUP_ID:                  VPC Security Group ID for the ECS task.
+# - BOT_TOKEN:                     GitHub PAT used to register the runner to the repo.
+# - EKS_CLUSTER_NAME:              The name of the EKS cluster for kubectl operations.
+# - TRACING_STORE_SECRET_ARN:      AWS Secrets Manager ARN for DB username/password.
+#
+# --------------------------------------------------------------------------------------
+# 3. WORKFLOW INPUTS & LOGICAL DEFAULTS
+# --------------------------------------------------------------------------------------
+# These inputs control which environment is read and the workflow behavior.
+#
+# - environment:                   Default: "tracing-qa". The GitHub Environment to use.
+# - runDataPreparation:            Default: false. Whether to wipe and reload S3 dumps.
+# - runJavaTests:                  Default: true. Whether to execute Maven/Java tests.
+# - javaTestSuite:                 Default: "NrtTest". The specific Java class to run.
+# - javaBranchName:                Default: "main". The branch of 'pn-b2b-client' to clone.
+#
+# --------------------------------------------------------------------------------------
+# 4. CROSS-ENVIRONMENT USAGE
+# --------------------------------------------------------------------------------------
+# This workflow is designed for "Environment Isolation." It does not read secrets 
+# from "other" environments simultaneously. Instead:
+# - If triggered by 'schedule': It is forced to use 'tracing-qa' settings.
+# - If triggered by 'workflow_dispatch': It uses the environment selected by the user.
+# - Repository-level secrets/vars: Used only if they are not overridden at the 
+#   Environment level.
+# ======================================================================================
+
 on:
   schedule:
     - cron: '45 18 * * 1-5'
@@ -150,8 +216,8 @@ jobs:
     if: ${{ always() && needs.workflow_context.outputs.runDataPreparation == 'true' && needs.create_runner.result == 'success' }}
     env:
       K8S_NAMESPACE: ${{ vars.K8S_NAMESPACE }}
-      PLATFORM_DATA_HOST: ${{ vars.PLATFORM_DATA_HOST }}
-      PLATFORM_DATA_PORT: 5432
+      TRACING_STORE_HOST: ${{ vars.TRACING_STORE_HOST }}
+      TRACING_STORE_PORT: 5432
       LOCAL_TRACING_DUMPS: "./db_dumps/tracing"
       MAX_POLLING_TRIES: "${{ vars.MAX_POLLING_TRIES }}"
       POLLING_SLEEP_TIME: "${{ vars.POLLING_SLEEP_TIME }}"
@@ -166,9 +232,7 @@ jobs:
         run: |
             set -euo pipefail
 
-            mkdir -p $LOCAL_TENANT_DUMPS
-            mkdir -p $LOCAL_ATTRIBUTE_REGISTRY_DUMPS
-            mkdir -p $LOCAL_NOTIFICATION_CONFIG_DUMPS
+            mkdir -p $LOCAL_TRACING_DUMPS
 
       - name: Get dump from S3
         id: get_data_dumps
@@ -177,9 +241,7 @@ jobs:
         run: |
             set -euo pipefail
 
-            aws s3 cp "s3://${{ vars.DATA_PREPARATION_BUCKET }}/${{ vars.TENANT_DUMP_S3_PREFIX }}" $LOCAL_TENANT_DUMPS --recursive
-            aws s3 cp "s3://${{ vars.DATA_PREPARATION_BUCKET }}/${{ vars.ATTRIBUTE_REGISTRY_DUMP_S3_PREFIX }}" $LOCAL_ATTRIBUTE_REGISTRY_DUMPS --recursive
-            aws s3 cp "s3://${{ vars.DATA_PREPARATION_BUCKET }}/${{ vars.NOTIFICATION_CONFIG_DUMP_S3_PREFIX }}" $LOCAL_NOTIFICATION_CONFIG_DUMPS --recursive
+            aws s3 cp "s3://${{ vars.DATA_PREPARATION_BUCKET }}/${{ vars.TRACING_DUMP_S3_PREFIX }}" $LOCAL_TRACING_DUMPS --recursive
 
       - name: Scale down Deployments
         id: svc_scale_to_0
@@ -218,36 +280,36 @@ jobs:
             done
             echo "All the deployments have been scaled down to 0 replicas."
 
-      - name: Get Platform Data Credentials
-        id: get_platform_data_db_credentials
+      - name: Get Tracing Store Credentials
+        id: get_tracing_store_db_credentials
         env:
-          PLATFORM_DATA_SECRET_ARN: ${{ secrets.PLATFORM_DATA_SECRET_ARN }}
+          TRACING_STORE_SECRET_ARN: ${{ secrets.TRACING_STORE_SECRET_ARN }}
         shell: bash
         run: |
             set -euo pipefail
 
-            echo "Retrieving Platform Data credentials..."
+            echo "Retrieving Tracing Store credentials..."
 
-            PLATFORM_DATA_CREDENTIALS="$(aws secretsmanager get-secret-value --secret-id $PLATFORM_DATA_SECRET_ARN)"
+            TRACING_STORE_CREDENTIALS="$(aws secretsmanager get-secret-value --secret-id $TRACING_STORE_SECRET_ARN)"
 
-            echo "Retrieve Platform Data username"
-            PLATFORM_DATA_USERNAME="$(jq -r '.SecretString | fromjson | .username' <<< "$PLATFORM_DATA_CREDENTIALS")"
+            echo "Retrieve Tracing Store username"
+            TRACING_STORE_USERNAME="$(jq -r '.SecretString | fromjson | .username' <<< "$TRACING_STORE_CREDENTIALS")"
 
-            echo "Retrieve Platform Data password"
-            PLATFORM_DATA_PASSWORD="$(jq -r '.SecretString | fromjson | .password' <<< "$PLATFORM_DATA_CREDENTIALS")"
+            echo "Retrieve Tracing Store password"
+            TRACING_STORE_PASSWORD="$(jq -r '.SecretString | fromjson | .password' <<< "$TRACING_STORE_CREDENTIALS")"
 
-            echo "Update env vars with Platform Data credentials"
-            echo "PLATFORM_DATA_USERNAME=$PLATFORM_DATA_USERNAME" >> "$GITHUB_ENV"
-            echo "PLATFORM_DATA_PASSWORD=$PLATFORM_DATA_PASSWORD" >> "$GITHUB_ENV"
+            echo "Update env vars with Tracing Store credentials"
+            echo "TRACING_STORE_USERNAME=$TRACING_STORE_USERNAME" >> "$GITHUB_ENV"
+            echo "TRACING_STORE_PASSWORD=$TRACING_STORE_PASSWORD" >> "$GITHUB_ENV"
 
       - name: Truncate Tracing DB Tables
         id: tracing_db_truncate
         shell: bash
         env:
-          PGUSER: ${{ env.PLATFORM_DATA_USERNAME }}
-          PGPASSWORD: ${{ env.PLATFORM_DATA_PASSWORD }}
-          PGHOST: ${{ env.PLATFORM_DATA_HOST }}
-          PGPORT: ${{ env.PLATFORM_DATA_PORT }}
+          PGUSER: ${{ env.TRACING_STORE_USERNAME }}
+          PGPASSWORD: ${{ env.TRACING_STORE_PASSWORD }}
+          PGHOST: ${{ env.TRACING_STORE_HOST }}
+          PGPORT: ${{ env.TRACING_STORE_PORT }}
           PGDATABASE: ${{ vars.TRACING_DB_NAME }}
         run: |
           $SCRIPTS_FOLDER/truncateSQLTables.sh
@@ -256,10 +318,10 @@ jobs:
         id: db_dump_restore
         shell: bash
         env:
-          PGUSER: ${{ env.PLATFORM_DATA_USERNAME }}
-          PGPASSWORD: ${{ env.PLATFORM_DATA_PASSWORD }}
-          PGHOST: ${{ env.PLATFORM_DATA_HOST }}
-          PGPORT: ${{ env.PLATFORM_DATA_PORT }}
+          PGUSER: ${{ env.TRACING_STORE_USERNAME }}
+          PGPASSWORD: ${{ env.TRACING_STORE_PASSWORD }}
+          PGHOST: ${{ env.TRACING_STORE_HOST }}
+          PGPORT: ${{ env.TRACING_STORE_PORT }}
           PGDATABASE: ${{ vars.TRACING_DB_NAME }}
         run: |
           $SCRIPTS_FOLDER/restoreTracing.sh

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -109,8 +109,6 @@ permissions:
   contents: read
 
 env:
-   skip_checkUserMembership: "true"
-   skip_failNotSelectedEnvTagRef: "true"
    SCRIPTS_FOLDER: "./scripts"
 
 jobs:

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -34,7 +34,7 @@ name: Tracing QA workflow
 # 2. ENVIRONMENT-SPECIFIC SECRETS (secrets)
 # --------------------------------------------------------------------------------------
 # - AWS_REGION:                    AWS Region for EKS, S3, and Secrets Manager.
-# - IAM_ROLE_ARN:                  The ARN of the role assumed by the ECS runner.
+# - ECS_IAM_ROLE_ARN:              The ARN of the role assumed by the ECS runner.
 # - ECS_CLUSTER_NAME:              The ECS cluster where the runner is spawned.
 # - ECS_TASK_DEFINITION:           The task definition ARN for the self-hosted runner.
 # - SUBNET_ID:                     VPC Subnet ID for the ECS task.
@@ -426,14 +426,14 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: qa-tests-log
-          path: ./pn-b2b-client/interop-qa-tests/qa-tests.log
+          path: ./pn-b2b-client/interop-qa-tests/tracing-qa-tests.log
 
       - name: Upload Cucumber Report
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cucumber-report
-          path: pn-b2b-client/interop-qa-tests/target/cucumber-report*
+          path: pn-b2b-client/interop-qa-tests/target/tracing-cucumber-report*
           retention-days: 10
 
   delete_runner:

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -377,53 +377,10 @@ jobs:
             sleep 2
           done
 
-  run_js_test:
-    name: Run JavaScript Cucumber Test Suite
-    if: ${{ always() && needs.workflow_context.outputs.runJSTests == 'true' }}
-    needs: [workflow_context, data_prep, create_runner]
-    runs-on: [self-hosted, "run_id:${{ needs.workflow_context.outputs.environment }}-${{ github.run_id }}"]
-    environment: ${{ needs.workflow_context.outputs.environment }}
-    env:
-      ENVIRONMENT: ${{ vars.ENVIRONMENT }}
-      SESSION_TOKENS_DURATION_SECONDS: ${{ vars.SESSION_TOKENS_DURATION_SECONDS }}
-      REMOTE_WELLKNOWN_URL: ${{ vars.REMOTE_WELLKNOWN_URL }}
-      ST_VERBOSE_MODE: ${{ vars.ST_VERBOSE_MODE }}
-      TENANTS_IDS_FILE_PATH: ${{ vars.TENANTS_IDS_FILE_PATH }}
-      CUCUMBER_OPTS_PARALLEL: ${{ vars.CUCUMBER_OPTS_PARALLEL }}
-      MAX_POLLING_TRIES:  ${{ vars.MAX_POLLING_TRIES }}
-      POLLING_SLEEP_TIME: ${{ vars.POLLING_SLEEP_TIME }}
-      AUTHORIZATION_SERVER_TOKEN_CREATION_URL: ${{ vars.AUTHORIZATION_SERVER_TOKEN_CREATION_URL }}
-      CLIENT_ASSERTION_JWT_AUDIENCE: ${{ vars.CLIENT_ASSERTION_JWT_AUDIENCE }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version-file: ./package.json
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          run_install: true
-
-      - name: Run QA tests
-        id: run_qa_tests
-        shell: bash
-        run: |
-          set -uo pipefail
-
-          echo "Install node dependencies"
-          pnpm i
-
-          echo "Run test command"
-          pnpm test
-
   run_java_test:
     name: Run Java Cucumber Test Suite
     if: ${{ always() && needs.create_runner.result == 'success' && needs.workflow_context.outputs.runJSTests != 'true' && needs.workflow_context.outputs.runJavaTests == 'true' }}
-    needs: [workflow_context, create_runner, data_prep, run_js_test]
+    needs: [workflow_context, create_runner, data_prep]
     runs-on: [self-hosted, "run_id:${{ needs.workflow_context.outputs.environment }}-${{ github.run_id }}"]
     environment: ${{ needs.workflow_context.outputs.environment }}
     env:
@@ -481,7 +438,7 @@ jobs:
 
   delete_runner:
     name: Delete Self-Hosted Runner
-    needs: [workflow_context, create_runner, data_prep, run_js_test, run_java_test]
+    needs: [workflow_context, create_runner, data_prep, run_java_test]
     if: ${{ always() }}
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -24,7 +24,6 @@ name: Tracing QA workflow
 # - ECS_TASK_MAX_DURATION_SECONDS: Max lifecycle time for the ephemeral self-hosted runner.
 # - ENVIRONMENT:                   A string label passed to test suites (e.g., "dev" or "qa").
 # - REMOTE_WELLKNOWN_URL:          OIDC discovery URL for authentication tests.
-# - BFF_BASE_URL:                  The base URL for the Backend-for-Frontend service.
 # - ST_VERBOSE_MODE:               Boolean flag to enable/disable verbose test logging.
 # - TENANTS_IDS_FILE_PATH:         Path to the JSON/data file containing test tenant IDs.
 # - CLIENT_ASSERTION_JWT_AUDIENCE: The 'aud' claim required for JWT client assertions.
@@ -391,7 +390,6 @@ jobs:
       ENVIRONMENT: ${{ vars.ENVIRONMENT }}
       SESSION_TOKENS_DURATION_SECONDS: ${{ vars.SESSION_TOKENS_DURATION_SECONDS }}
       REMOTE_WELLKNOWN_URL: ${{ vars.REMOTE_WELLKNOWN_URL }}
-      BFF_BASE_URL: ${{ vars.BFF_BASE_URL }}
       ST_VERBOSE_MODE: ${{ vars.ST_VERBOSE_MODE }}
       TENANTS_IDS_FILE_PATH: ${{ vars.TENANTS_IDS_FILE_PATH }}
       CUCUMBER_OPTS_PARALLEL: ${{ vars.CUCUMBER_OPTS_PARALLEL }}

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -66,9 +66,6 @@ name: Tracing QA workflow
 # ======================================================================================
 
 on:
-  schedule:
-    - cron: '45 18 * * 1-5'
-      timezone: "Europe/Rome"
   workflow_dispatch:
     inputs:
       environment:
@@ -146,8 +143,8 @@ jobs:
             runDataPreparation="true"
             runJSTests="false"
             runJavaTests="true"
-            javaTestSuite="NRTStandard"
-            javaBranchName="develop"
+            javaTestSuite="PLACEHOLDER"
+            javaBranchName="PLACEHOLDER"
           else
             environment="${{ inputs.environment }}"
             runDataPreparation="${{ inputs.runDataPreparation }}"

--- a/scripts/restoreTracing.sh
+++ b/scripts/restoreTracing.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Concepts.General.SSL.html
+#https://www.postgresql.org/docs/13/libpq-envars.html
+
+set -euo pipefail
+set +f
+
+PSQL_BIN=psql
+
+echo "psql version" $($PSQL_BIN --version)
+
+for f in "$LOCAL_TRACING_DUMPS"/*; do
+  echo "Tracing: restoring dump $f"
+  $PSQL_BIN --set ON_ERROR_STOP=on < "$f"
+done;


### PR DESCRIPTION
This PR introduces a dedicated GitHub Actions workflow to run interop-tracing QA/e2e tests (scheduled and manually triggered), and aligns the existing QA workflow’s environment input to a fixed set of allowed environments.

**Changes:**
- Added a new workflow `.github/workflows/tracing-qa.yaml` to run tracing QA (data prep + Java e2e suite) on schedule/dispatch.
- Updated `.github/workflows/qa.yaml` to make the `environment` workflow input a `choice` with explicit options.

