### PR TITLE
PIN-9926: fix log file name

### DIFF
--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -419,7 +419,7 @@ jobs:
           echo "Using Spring profile: ${SPRING_PROFILE}"
 
           cd ./pn-b2b-client/interop-qa-tests
-          mvn $SPRING_PROFILE -Dtest=it.pagopa.pn.interop.cucumber.${{ needs.workflow_context.outputs.javaTestSuite }} clean verify > qa-tests.log 2>&1
+          mvn $SPRING_PROFILE -Dtest=it.pagopa.pn.interop.cucumber.${{ needs.workflow_context.outputs.javaTestSuite }} clean verify > tracing-qa-tests.log 2>&1
 
       - name: Upload QA test logs
         if: always()


### PR DESCRIPTION
This PR updates the tracing QA GitHub Actions workflow to write Maven test output to a tracing-specific log file name, aligning the generated log with the artifact upload path in that workflow.

**Changes:**
- Rename the Maven stdout/stderr redirect output from `qa-tests.log` to `tracing-qa-tests.log` in the tracing QA workflow.