### PR TITLE
PIN-9967 fix scaleup after datapreparation

### DIFF
--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -94,12 +94,12 @@ on:
       javaTestSuite:
         description: 'Choose which Java test suite to run'
         required: false
-        default: NrtTest
+        default: InteropTracingTest
         type: string
       javaBranchName:
         description: 'Provide the branch name for pn-b2b-client to clone'
         required: false
-        default: main
+        default: feature/QA-13610-tracing-refactoring
         type: string
 
 
@@ -144,15 +144,15 @@ jobs:
             runDataPreparation="true"
             runJSTests="false"
             runJavaTests="true"
-            javaTestSuite="PLACEHOLDER"
-            javaBranchName="PLACEHOLDER"
+            javaTestSuite="InteropTracingTest"
+            javaBranchName="feature/QA-13610-tracing-refactoring"
           else
             environment="${{ inputs.environment }}"
             runDataPreparation="${{ inputs.runDataPreparation }}"
             runJSTests="false"
             runJavaTests="${{ inputs.runJavaTests }}"
-            javaTestSuite="${{ inputs.javaTestSuite || 'NRTStandard' }}"
-            javaBranchName="${{ inputs.javaBranchName || 'develop' }}"
+            javaTestSuite="${{ inputs.javaTestSuite || 'InteropTracingTest' }}"
+            javaBranchName="${{ inputs.javaBranchName || 'feature/QA-13610-tracing-refactoring' }}"
           fi
 
           {
@@ -328,6 +328,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          # Not all environment have scaledobjects
+          kubectl scale deployment -n $K8S_NAMESPACE --replicas=1 --all
 
           for scaledobject in $(kubectl get scaledobjects -n $K8S_NAMESPACE -o jsonpath='{.items[*].metadata.name}'); do
             echo "Resuming ScaledObject: $scaledobject"

--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -329,7 +329,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Not all environment have scaledobjects
+          # Not all environments have ScaledObjects. Scale every deployment to 1 replica
+          # first so deployments without a ScaledObject are also brought back up; the
+          # resume loop below only affects deployments managed by KEDA.
           kubectl scale deployment -n $K8S_NAMESPACE --replicas=1 --all
 
           for scaledobject in $(kubectl get scaledobjects -n $K8S_NAMESPACE -o jsonpath='{.items[*].metadata.name}'); do


### PR DESCRIPTION

Fixes the post-data-preparation scale-up step in the tracing QA workflow so that deployments without a KEDA `ScaledObject` are also brought back up, and updates the default Java test suite and branch inputs.

**Changes:**
- Adds an explicit `kubectl scale deployment --replicas=1 --all` before resuming `ScaledObject`s, ensuring deployments not managed by KEDA are scaled back up.
- Changes `javaTestSuite` defaults from `NrtTest`/`NRTStandard` to `InteropTracingTest` (both schedule path and manual fallback).
- Changes `javaBranchName` defaults from `main`/`develop` to `feature/QA-13610-tracing-refactoring` (both schedule path and manual fallback).



