### PR TITLE
chore: PIN-9967 activate scheduling

### DIFF
--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -66,9 +66,9 @@ name: Tracing QA workflow
 # ======================================================================================
 
 on:
-  #schedule:
-  #  - cron: '45 18 * * 1-5'
-  #    timezone: "Europe/Rome"
+  schedule:
+    - cron: '45 18 * * 1-5'
+      timezone: "Europe/Rome"
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION

This PR activates the previously commented-out cron schedule for the “Tracing QA workflow”, allowing it to run automatically on weekdays at the configured time (Europe/Rome), in addition to still supporting manual `workflow_dispatch` runs.

**Changes:**
- Uncommented the `on.schedule` trigger in `.github/workflows/tracing-qa.yaml` (weekday cron).