### PR TITLE
chore: diasble QA tracing test scheduling due to github workflow start random delay

### DIFF
--- a/.github/workflows/tracing-qa.yaml
+++ b/.github/workflows/tracing-qa.yaml
@@ -66,9 +66,11 @@ name: Tracing QA workflow
 # ======================================================================================
 
 on:
-  schedule:
-    - cron: '45 18 * * 1-5'
-      timezone: "Europe/Rome"
+  # Commented out because github scheduling random late cause workflow start when
+  # database is shutdown for cost saving reason.
+  #schedule:
+  #  - cron: '45 18 * * 1-5'
+  #    timezone: "Europe/Rome"
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
Disables the scheduled trigger for the Tracing QA workflow because GitHub's scheduling latency can start the workflow when the target database is shut down for cost-saving. The workflow can still be invoked manually via `workflow_dispatch`.

**Changes:**
- Comment out the `schedule` trigger (cron `45 18 * * 1-5`, `Europe/Rome`) in `tracing-qa.yaml`.
- Add an explanatory comment about why the schedule was disabled.
