### PR TITLE
feat(workflow): add new dumps from s3 to qa-workflow for manual-archiving

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -237,6 +237,8 @@ jobs:
       LOCAL_TENANT_JOURNAL_TABLE_NAME: "event_journal"
       LOCAL_TENANT_TAG_TABLE_NAME: "event_tag"
       LOCAL_NOTIFICATION_CONFIG_DUMPS: "./db_dumps/notification_config"
+      LOCAL_AGREEMENT_DUMPS: "./db_dumps/agreement"
+      LOCAL_CATALOG_DUMPS: "./db_dumps/catalog"
       MAX_POLLING_TRIES: "${{ vars.MAX_POLLING_TRIES }}"
       POLLING_SLEEP_TIME: "${{ vars.POLLING_SLEEP_TIME }}"
       DYNAMODB_PLATFORM_STATES_TABLE: ${{ vars.platformStatesTableName }}
@@ -255,6 +257,8 @@ jobs:
             mkdir -p $LOCAL_TENANT_DUMPS
             mkdir -p $LOCAL_ATTRIBUTE_REGISTRY_DUMPS
             mkdir -p $LOCAL_NOTIFICATION_CONFIG_DUMPS
+            mkdir -p $LOCAL_AGREEMENT_DUMPS
+            mkdir -p $LOCAL_CATALOG_DUMPS
 
       - name: Get dump from S3
         id: get_data_dumps
@@ -266,6 +270,8 @@ jobs:
             aws s3 cp "s3://${{ vars.DATA_PREPARATION_BUCKET }}/${{ vars.TENANT_DUMP_S3_PREFIX }}" $LOCAL_TENANT_DUMPS --recursive
             aws s3 cp "s3://${{ vars.DATA_PREPARATION_BUCKET }}/${{ vars.ATTRIBUTE_REGISTRY_DUMP_S3_PREFIX }}" $LOCAL_ATTRIBUTE_REGISTRY_DUMPS --recursive
             aws s3 cp "s3://${{ vars.DATA_PREPARATION_BUCKET }}/${{ vars.NOTIFICATION_CONFIG_DUMP_S3_PREFIX }}" $LOCAL_NOTIFICATION_CONFIG_DUMPS --recursive
+            aws s3 cp "s3://${{ vars.DATA_PREPARATION_BUCKET }}/${{ vars.AGREEMENT_DUMP_S3_PREFIX }}" $LOCAL_AGREEMENT_DUMPS --recursive
+            aws s3 cp "s3://${{ vars.DATA_PREPARATION_BUCKET }}/${{ vars.CATALOG_DUMP_S3_PREFIX }}" $LOCAL_CATALOG_DUMPS --recursive
 
       - name: Scale down Deployments
         id: svc_scale_to_0


### PR DESCRIPTION
This PR edits the `mkdir_dump` and `get_data_dumps` steps into the `data_prep` job to manage new dumps required by the manual-archiving feature as requested by developers 